### PR TITLE
Fix: Remove backwards compatibility for older Tekton container naming structure.

### DIFF
--- a/cmd/nebula-secret-auth-controller/main.go
+++ b/cmd/nebula-secret-auth-controller/main.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 	"time"
 
-	_ "github.com/puppetlabs/nebula-libs/storage/gcs"
 	"github.com/puppetlabs/horsehead/storage"
+	_ "github.com/puppetlabs/nebula-libs/storage/gcs"
 	"github.com/puppetlabs/nebula-tasks/pkg/config"
 	"github.com/puppetlabs/nebula-tasks/pkg/controllers/secretauth"
 	"github.com/puppetlabs/nebula-tasks/pkg/data/secrets/vault"

--- a/pkg/controllers/secretauth/controller.go
+++ b/pkg/controllers/secretauth/controller.go
@@ -444,21 +444,12 @@ func (c *Controller) uploadLogs(ctx context.Context, plr *tekv1alpha1.PipelineRu
 		if _, ok := plr.Annotations[annotation]; ok {
 			continue
 		}
-		var containerName, logName string
-		var err error
-		for _, containerName = range []string{"step-" + pt.TaskName, "build-step-" + pt.TaskName} {
-			logName, err = c.uploadLog(ctx, plr.Namespace, pt.PodName, containerName)
-			if nil != err {
-				if errors.IsBadRequest(err) {
-					continue
-				}
-				break
-			}
-		}
+		containerName := "step-" + pt.TaskName
+		logName, err := c.uploadLog(ctx, plr.Namespace, pt.PodName, containerName)
 		if nil != err {
-			klog.Warningf("Failed to upload log for podName=%s taskName=%s containerName=%s %+v",
+			klog.Warningf("Failed to upload log for pod=%s/%s container=%s %+v",
+				plr.Namespace,
 				pt.PodName,
-				pt.TaskName,
 				containerName,
 				err)
 			return err


### PR DESCRIPTION
I tested on my laptop, connected to `gke_nebula-235818_us-west1_app-cluster-stage-1-primary`, and the log uploads are succeeding on my laptop with this change.

Note that the root cause of the old code causing problems is the fact that we need to `break` from the `for` loop if `err == nil`.

...so the old code worked only when running against old Tekton versions (which use the `build-step-*` prefix).