### PR TITLE
Adding task interface support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,13 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20190729175742-ef12d49c8daf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
-	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/imdario/mergo v0.3.7
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/knative/pkg v0.0.0-20190624141606-d82505e6c5b4 // indirect
 	github.com/markbates/inflect v1.0.4 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/puppetlabs/errawr-gen v1.0.0
 	github.com/puppetlabs/errawr-go/v2 v2.1.0
@@ -35,6 +36,7 @@ require (
 	google.golang.org/api v0.7.0
 	google.golang.org/grpc v1.22.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190515023547-db5a9d1c40eb
 	k8s.io/apimachinery v0.0.0-20190515023456-b74e4c97951f
 	k8s.io/client-go v0.0.0-20190515063710-7b18d6600f6b

--- a/pkg/cmd/cluster.go
+++ b/pkg/cmd/cluster.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/task"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/spf13/cobra"
+)
+
+func NewClusterCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "cluster",
+		Short:                 "Manage cluster configuration",
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.AddCommand(NewClusterConfigCommand())
+
+	return cmd
+}
+
+func NewClusterConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "config",
+		Short:                 "Create cluster config",
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			directory, _ := cmd.Flags().GetString("directory")
+
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			task := task.NewTaskInterface(planOpts)
+			return task.ProcessClusters(directory)
+		},
+	}
+
+	cmd.Flags().StringP("directory", "d", "", "configuration output directory")
+
+	return cmd
+}

--- a/pkg/cmd/credentials.go
+++ b/pkg/cmd/credentials.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/task"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCredentialsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "credentials",
+		Short:                 "Manage credentials configuration",
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.AddCommand(NewCredentialsConfigCommand())
+
+	return cmd
+}
+
+func NewCredentialsConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "config",
+		Short:                 "Create credentials configuration",
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			directory, _ := cmd.Flags().GetString("directory")
+
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			task := task.NewTaskInterface(planOpts)
+			return task.ProcessCredentials(directory)
+		},
+	}
+
+	cmd.Flags().StringP("directory", "d", "", "configuration output directory")
+
+	return cmd
+}

--- a/pkg/cmd/file.go
+++ b/pkg/cmd/file.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/task"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/spf13/cobra"
+)
+
+func NewFileCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "file",
+		Short:                 "WriteFile specification data to a file",
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			file, _ := cmd.Flags().GetString("file")
+			path, _ := cmd.Flags().GetString("path")
+			output, _ := cmd.Flags().GetString("output")
+
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			task := task.NewTaskInterface(planOpts)
+			return task.WriteFile(file, path, output)
+		},
+	}
+
+	cmd.Flags().StringP("file", "f", "", "file name")
+	cmd.Flags().StringP("path", "p", "", "specification data path")
+	cmd.Flags().StringP("output", "o", "", "output type")
+
+	return cmd
+}

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/task"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/spf13/cobra"
+)
+
+func NewGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "get",
+		Short:                 "Get specification data",
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, _ := cmd.Flags().GetString("path")
+
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			task := task.NewTaskInterface(planOpts)
+			data, err := task.ReadData(path)
+			if err != nil {
+				return err
+			}
+
+			cmd.OutOrStdout().Write(data)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("path", "p", "", "specification data path")
+
+	return cmd
+}

--- a/pkg/cmd/git.go
+++ b/pkg/cmd/git.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/task"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/spf13/cobra"
+)
+
+func NewGitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "git",
+		Short:                 "Manage git data",
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.AddCommand(NewGitCloneCommand())
+
+	return cmd
+}
+
+func NewGitCloneCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "clone",
+		Short:                 "Clone git repository",
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			directory, _ := cmd.Flags().GetString("directory")
+			revision, _ := cmd.Flags().GetString("revision")
+
+			planOpts := taskutil.DefaultPlanOptions{SpecURL: os.Getenv(taskutil.SpecURLEnvName)}
+			task := task.NewTaskInterface(planOpts)
+			return task.CloneRepository(revision, directory)
+		},
+	}
+
+	cmd.Flags().StringP("revision", "r", "", "git revision")
+	cmd.Flags().StringP("directory", "d", "", "git clone output directory")
+
+	return cmd
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -12,5 +12,11 @@ func NewRootCommand() (*cobra.Command, error) {
 		SilenceErrors: true,
 	}
 
+	c.AddCommand(NewClusterCommand())
+	c.AddCommand(NewCredentialsCommand())
+	c.AddCommand(NewFileCommand())
+	c.AddCommand(NewGetCommand())
+	c.AddCommand(NewGitCommand())
+
 	return c, nil
 }

--- a/pkg/model/spec.go
+++ b/pkg/model/spec.go
@@ -1,0 +1,29 @@
+package model
+
+type CredentialSpec struct {
+	Credentials map[string]string `json:"credentials"`
+}
+
+type GitSpec struct {
+	GitRepository *GitDetails `json:"git"`
+}
+
+type GitDetails struct {
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
+	SSHKey     string `json:"ssh_key"`
+	KnownHosts string `json:"known_hosts"`
+}
+type ClusterSpec struct {
+	Cluster *ClusterDetails `json:"cluster"`
+}
+
+type ClusterDetails struct {
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	CAData   string `json:"cadata"`
+	Token    string `json:"token"`
+	Insecure bool   `json:"insecure"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}

--- a/pkg/task/cluster.go
+++ b/pkg/task/cluster.go
@@ -1,0 +1,112 @@
+package task
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/imdario/mergo"
+	"github.com/puppetlabs/nebula-tasks/pkg/model"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func (ti *TaskInterface) ProcessClusters(directory string) error {
+
+	var spec model.ClusterSpec
+	if err := taskutil.PopulateSpecFromDefaultPlan(&spec, ti.opts); err != nil {
+		return err
+	}
+
+	cluster := retrieveClusterFromEnvironment()
+
+	if cluster != nil && spec.Cluster != nil {
+		if err := mergo.Merge(cluster, spec.Cluster); err != nil {
+			return err
+		}
+	}
+
+	if cluster.Name == "" {
+		cluster.Name = DefaultName
+	}
+
+	return CreateKubeconfigFile(directory, cluster)
+}
+
+func CreateKubeconfigFile(directory string, resource *model.ClusterDetails) error {
+	if resource == nil {
+		return nil
+	}
+
+	cluster := &clientcmdapi.Cluster{
+		Server:                resource.URL,
+		InsecureSkipTLSVerify: resource.Insecure,
+	}
+
+	if resource.CAData != "" {
+		ca, err := base64.StdEncoding.DecodeString(resource.CAData)
+		if err != nil {
+			return err
+		}
+		cluster.CertificateAuthorityData = ca
+	}
+
+	//only one authentication technique per user is allowed in a kubeconfig, so clear out the password if a token is provided
+	user := resource.Username
+	pass := resource.Password
+	if resource.Token != "" {
+		user = ""
+		pass = ""
+	}
+	auth := &clientcmdapi.AuthInfo{
+		Token:    resource.Token,
+		Username: user,
+		Password: pass,
+	}
+	context := &clientcmdapi.Context{
+		Cluster:  resource.Name,
+		AuthInfo: resource.Username,
+	}
+	c := clientcmdapi.NewConfig()
+	c.Clusters[resource.Name] = cluster
+	c.AuthInfos[resource.Username] = auth
+	c.Contexts[resource.Name] = context
+	c.CurrentContext = resource.Name
+	c.APIVersion = "v1"
+	c.Kind = "Config"
+
+	if directory == "" {
+		directory = DefaultPath
+	}
+
+	destination := filepath.Join(directory, resource.Name, KubeConfigFile)
+	return clientcmd.WriteToFile(*c, destination)
+}
+
+func retrieveClusterFromEnvironment() *model.ClusterDetails {
+
+	cluster := &model.ClusterDetails{}
+
+	if nameFromEnv := os.Getenv("CLUSTER_NAME"); nameFromEnv != "" {
+		cluster.Name = nameFromEnv
+	}
+	if urlFromEnv := os.Getenv("CLUSTER_URL"); urlFromEnv != "" {
+		cluster.URL = urlFromEnv
+	}
+	if caFromEnv := os.Getenv("CLUSTER_CADATA"); caFromEnv != "" {
+		cluster.CAData = caFromEnv
+	}
+	if tokenFromEnv := os.Getenv("CLUSTER_TOKEN"); tokenFromEnv != "" {
+		cluster.Token = strings.TrimRight(tokenFromEnv, "\r\n")
+	}
+	if usernameFromEnv := os.Getenv("CLUSTER_USERNAME"); usernameFromEnv != "" {
+		cluster.Username = usernameFromEnv
+	}
+	if passwordFromEnv := os.Getenv("CLUSTER_PASSWORD"); passwordFromEnv != "" {
+		cluster.Password = passwordFromEnv
+	}
+
+	return cluster
+}

--- a/pkg/task/cluster_test.go
+++ b/pkg/task/cluster_test.go
@@ -1,0 +1,47 @@
+package task
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/model"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/puppetlabs/nebula-tasks/pkg/testutil"
+)
+
+func TestClusterOutput(t *testing.T) {
+	t.Skip("Functional testing harness. Needs to be completed.")
+
+	data := base64.StdEncoding.EncodeToString([]byte("cadata"))
+
+	testSpec := &model.ClusterSpec{
+		Cluster: &model.ClusterDetails{
+			Name:   "test1",
+			Token:  "tokendata",
+			CAData: data,
+			URL:    "url",
+		},
+	}
+
+	opts := testutil.MockMetadataAPIOptions{
+		Name:           "test1",
+		ResponseObject: testSpec,
+	}
+
+	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
+		opts := taskutil.DefaultPlanOptions{
+			Client:  ts.Client(),
+			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+		}
+
+		task := NewTaskInterface(opts)
+
+		err := task.ProcessClusters("output")
+		require.Nil(t, err, "err is not nil")
+	}, opts)
+}

--- a/pkg/task/credentials.go
+++ b/pkg/task/credentials.go
@@ -1,0 +1,29 @@
+package task
+
+import (
+	"path/filepath"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/model"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+)
+
+func (ti *TaskInterface) ProcessCredentials(directory string) error {
+	var spec model.CredentialSpec
+	if err := taskutil.PopulateSpecFromDefaultPlan(&spec, ti.opts); err != nil {
+		return err
+	}
+
+	if directory == "" {
+		directory = DefaultPath
+	}
+
+	for name, credentials := range spec.Credentials {
+		destination := filepath.Join(directory, name)
+		err := taskutil.WriteToFile(destination, credentials)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/task/credentials_test.go
+++ b/pkg/task/credentials_test.go
@@ -1,0 +1,46 @@
+package task
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/model"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/puppetlabs/nebula-tasks/pkg/testutil"
+)
+
+func TestCredentialOutput(t *testing.T) {
+	t.Skip("Functional testing harness. Needs to be completed.")
+
+	credentialSpec := make(map[string]string)
+
+	data := base64.StdEncoding.EncodeToString([]byte("testdata"))
+	credentialSpec["ca.pem"] = data
+	credentialSpec["key.pem"] = data
+
+	testSpec := &model.CredentialSpec{
+		Credentials: credentialSpec,
+	}
+
+	opts := testutil.MockMetadataAPIOptions{
+		Name:           "test1",
+		ResponseObject: testSpec,
+	}
+
+	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
+		opts := taskutil.DefaultPlanOptions{
+			Client:  ts.Client(),
+			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+		}
+
+		task := NewTaskInterface(opts)
+
+		err := task.ProcessCredentials("output")
+		require.Nil(t, err, "err is not nil")
+	}, opts)
+}

--- a/pkg/task/file.go
+++ b/pkg/task/file.go
@@ -1,0 +1,38 @@
+package task
+
+import (
+	"encoding/json"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"gopkg.in/yaml.v2"
+)
+
+func (ti *TaskInterface) WriteFile(file, path, output string) error {
+	var spec map[string]interface{}
+	if err := taskutil.PopulateSpecFromDefaultPlan(&spec, ti.opts); err != nil {
+		return err
+	}
+
+	data, err := GetData(spec, path, output)
+	if err != nil {
+		return err
+	}
+
+	if data != nil {
+		return taskutil.WriteDataToFile(file, data)
+	}
+
+	return nil
+}
+
+func GetData(spec map[string]interface{}, path, output string) ([]byte, error) {
+	switch output {
+	case "json":
+		return json.Marshal(spec[path])
+
+	default:
+		return yaml.Marshal(spec[path])
+	}
+
+	return nil, nil
+}

--- a/pkg/task/file_test.go
+++ b/pkg/task/file_test.go
@@ -1,0 +1,50 @@
+package task
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/puppetlabs/nebula-tasks/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type TestValues struct {
+	Name    string   `yaml:"name" json:"name"`
+	SomeNum int      `yaml:"someNum" json:"someNum"`
+	Data    []string `yaml:"data" json:"data"`
+}
+
+type TestSpec struct {
+	Values *TestValues `yaml:"values" json:"values"`
+}
+
+func TestGetFileOutput(t *testing.T) {
+	t.Skip("Functional testing harness. Needs to be completed.")
+
+	testSpec := &TestSpec{
+		Values: &TestValues{
+			Name:    "test1",
+			SomeNum: 12,
+			Data:    []string{"something", "else"},
+		},
+	}
+
+	opts := testutil.MockMetadataAPIOptions{
+		Name:           "test1",
+		ResponseObject: testSpec,
+	}
+
+	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
+		opts := taskutil.DefaultPlanOptions{
+			Client:  ts.Client(),
+			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+		}
+
+		task := NewTaskInterface(opts)
+
+		err := task.WriteFile("output/values-test.yml", "values", "yaml")
+		require.Nil(t, err, "err is not nil")
+	}, opts)
+}

--- a/pkg/task/get.go
+++ b/pkg/task/get.go
@@ -1,0 +1,27 @@
+package task
+
+import (
+	"encoding/json"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+)
+
+func (ti *TaskInterface) ReadData(path string) ([]byte, error) {
+	var spec map[string]interface{}
+
+	if err := taskutil.PopulateSpecFromDefaultPlan(&spec, ti.opts); err != nil {
+		return nil, err
+	}
+
+	if path != "" {
+		output, _ := taskutil.EvaluateJSONPath(path, spec)
+		if output != nil {
+			return output.Bytes(), nil
+		}
+	} else {
+		output, _ := json.Marshal(spec)
+		return output, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/task/get_test.go
+++ b/pkg/task/get_test.go
@@ -1,0 +1,52 @@
+package task
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/puppetlabs/nebula-tasks/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type TestGetSpec struct {
+	Name    string   `json:"name"`
+	SomeNum int      `json:"someNum"`
+	Data    []string `json:"data"`
+}
+
+func TestGetOutput(t *testing.T) {
+	testSpec := &TestGetSpec{
+		Name:    "test1",
+		SomeNum: 12,
+		Data:    []string{"something", "else"},
+	}
+
+	opts := testutil.MockMetadataAPIOptions{
+		Name:           "test1",
+		ResponseObject: testSpec,
+	}
+
+	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
+		opts := taskutil.DefaultPlanOptions{
+			Client:  ts.Client(),
+			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+		}
+
+		task := NewTaskInterface(opts)
+
+		output, _ := task.ReadData("{.name}")
+		require.Equal(t, testSpec.Name, string(output))
+
+		output, _ = task.ReadData("{.someNum}")
+		require.Equal(t, strconv.Itoa(testSpec.SomeNum), string(output))
+
+		output, _ = task.ReadData("{.data[0]}")
+		require.Equal(t, testSpec.Data[0], string(output))
+
+		output, _ = task.ReadData("{.data[1]}")
+		require.Equal(t, testSpec.Data[1], string(output))
+	}, opts)
+}

--- a/pkg/task/git.go
+++ b/pkg/task/git.go
@@ -1,0 +1,91 @@
+package task
+
+import (
+	"encoding/base64"
+	"errors"
+	"path/filepath"
+	"regexp"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/model"
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+)
+
+var gitSSHUrl = regexp.MustCompile(`^git@([a-zA-Z0-9\-\.]+):(.+)/(.+)\.git$`)
+
+func (ti *TaskInterface) CloneRepository(revision string, directory string) error {
+	var spec model.GitSpec
+	if err := taskutil.PopulateSpecFromDefaultPlan(&spec, ti.opts); err != nil {
+		return err
+	}
+
+	resource := spec.GitRepository
+	if resource == nil {
+		return nil
+	}
+
+	if resource.Name == "" {
+		resource.Name = DefaultName
+	}
+
+	if revision == "" {
+		revision = DefaultRevision
+	}
+
+	if directory == "" {
+		directory = DefaultPath
+	}
+
+	if resource.SSHKey != "" {
+		err := writeSSHConfig(resource)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := taskutil.Fetch(revision, filepath.Join(directory, resource.Name), resource.Repository)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeSSHConfig(resource *model.GitDetails) error {
+	gitConfig := taskutil.SSHConfig{}
+
+	matches := gitSSHUrl.FindStringSubmatch(resource.Repository)
+	if len(matches) <= 1 {
+		return errors.New("SSH URL is malformed")
+	}
+
+	host := matches[1]
+
+	gitConfig.Order = make([]string, 0)
+	gitConfig.Order = append(gitConfig.Order, host)
+	gitConfig.Entries = make(map[string]taskutil.SSHEntry, 0)
+
+	sshKey, err := base64.StdEncoding.DecodeString(resource.SSHKey)
+	if err != nil {
+		return err
+	}
+
+	knownHosts, err := base64.StdEncoding.DecodeString(resource.KnownHosts)
+	if err != nil {
+		return err
+	}
+
+	if len(knownHosts) == 0 || err != nil {
+		knownHosts, err = taskutil.SSHKeyScan(host)
+		if err != nil {
+			return err
+		}
+	}
+
+	gitConfig.Entries[host] = taskutil.SSHEntry{
+		Name:       resource.Name,
+		PrivateKey: string(sshKey),
+		KnownHosts: string(knownHosts),
+	}
+
+	return gitConfig.Write()
+}

--- a/pkg/task/git_test.go
+++ b/pkg/task/git_test.go
@@ -1,0 +1,44 @@
+package task
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/model"
+
+	"github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+	"github.com/puppetlabs/nebula-tasks/pkg/testutil"
+)
+
+func TestGitOutput(t *testing.T) {
+	t.Skip("Functional testing harness. Needs to be completed.")
+
+	testSpec := &model.GitSpec{
+		GitRepository: &model.GitDetails{
+			SSHKey:     "<ssh_key>",
+			KnownHosts: "<known_hosts>",
+			Name:       "<name>",
+			Repository: "<repository>",
+		},
+	}
+
+	opts := testutil.MockMetadataAPIOptions{
+		Name:           "test1",
+		ResponseObject: testSpec,
+	}
+
+	testutil.WithMockMetadataAPI(t, func(ts *httptest.Server) {
+		opts := taskutil.DefaultPlanOptions{
+			Client:  ts.Client(),
+			SpecURL: fmt.Sprintf("%s/specs/test1", ts.URL),
+		}
+
+		task := NewTaskInterface(opts)
+
+		err := task.CloneRepository("master", "output")
+		require.Nil(t, err, "err is not nil")
+	}, opts)
+}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -1,0 +1,18 @@
+package task
+
+import "github.com/puppetlabs/nebula-tasks/pkg/taskutil"
+
+const (
+	DefaultName     = "default"
+	DefaultPath     = "/workspace"
+	DefaultRevision = "master"
+	KubeConfigFile  = "kubeconfig"
+)
+
+type TaskInterface struct {
+	opts taskutil.DefaultPlanOptions
+}
+
+func NewTaskInterface(opts taskutil.DefaultPlanOptions) *TaskInterface {
+	return &TaskInterface{opts}
+}

--- a/pkg/taskutil/git.go
+++ b/pkg/taskutil/git.go
@@ -1,0 +1,79 @@
+package taskutil
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func run(cmd string, args ...string) error {
+	c := exec.Command(cmd, args...)
+	var output bytes.Buffer
+	c.Stderr = &output
+	c.Stdout = &output
+	if err := c.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Fetch fetches the specified git repository at the revision into path.
+func Fetch(revision, path, url string) error {
+	// HACK: This is to get git+ssh to work since ssh doesn't respect the HOME
+	// env variable.
+	homepath, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+	homeenv := os.Getenv("HOME")
+	euid := os.Geteuid()
+	// Special case the root user/directory
+	if euid == 0 {
+		if err := os.Symlink(homeenv+"/.ssh", "/root/.ssh"); err != nil {
+		}
+	} else if homeenv != "" && homeenv != homepath {
+		if _, err := os.Stat(homepath + "/.ssh"); os.IsNotExist(err) {
+			if err := os.Symlink(homeenv+"/.ssh", homepath+"/.ssh"); err != nil {
+			}
+		}
+	}
+
+	if revision == "" {
+		revision = "master"
+	}
+	if path != "" {
+		if err := run("git", "init", path); err != nil {
+			return err
+		}
+		if err := os.Chdir(path); err != nil {
+			return nil
+		}
+	} else {
+		if err := run("git", "init"); err != nil {
+			return err
+		}
+	}
+
+	trimmedURL := strings.TrimSpace(url)
+	if err := run("git", "remote", "add", "origin", trimmedURL); err != nil {
+		return err
+	}
+	if err := run("git", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", revision); err != nil {
+		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error
+		// as no guarantee that the same error is returned by all git servers gitlab, github etc...
+		if err := run("git", "pull", "--recurse-submodules=yes", "origin"); err != nil {
+			return err
+		}
+		if err := run("git", "checkout", revision); err != nil {
+			return err
+		}
+	} else {
+		if err := run("git", "reset", "--hard", "FETCH_HEAD"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/taskutil/jsonpath.go
+++ b/pkg/taskutil/jsonpath.go
@@ -1,0 +1,22 @@
+package taskutil
+
+import (
+	"bytes"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+func EvaluateJSONPath(jsonPath string, data interface{}) (*bytes.Buffer, error) {
+	j := jsonpath.New("expression")
+	if err := j.Parse(jsonPath); err != nil {
+		return nil, err
+	}
+
+	buf := &bytes.Buffer{}
+	err := j.Execute(buf, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}

--- a/pkg/taskutil/ssh.go
+++ b/pkg/taskutil/ssh.go
@@ -1,0 +1,91 @@
+package taskutil
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type SSHConfig struct {
+	Entries map[string]SSHEntry
+	Order   []string
+}
+
+func (dc *SSHConfig) String() string {
+	if dc == nil {
+		return ""
+	}
+	var urls []string
+	for _, k := range dc.Order {
+		v := dc.Entries[k]
+		urls = append(urls, fmt.Sprintf("%s=%s", v.Name, k))
+	}
+	return strings.Join(urls, ",")
+}
+
+func (dc *SSHConfig) Write() error {
+	sshDir := filepath.Join(os.Getenv("HOME"), ".ssh")
+	if err := os.MkdirAll(sshDir, os.ModePerm); err != nil {
+		return err
+	}
+	var configEntries []string
+	var defaultPort = "22"
+	var knownHosts []string
+	for _, k := range dc.Order {
+		var host, port string
+		var err error
+		if host, port, err = net.SplitHostPort(k); err != nil {
+			host = k
+			port = defaultPort
+		}
+		v := dc.Entries[k]
+		if err := v.Write(sshDir); err != nil {
+			return err
+		}
+		configEntries = append(configEntries, fmt.Sprintf(`Host %s
+    HostName %s
+    IdentityFile %s
+    Port %s
+`, host, host, v.path(sshDir), port))
+
+		knownHosts = append(knownHosts, v.KnownHosts)
+	}
+	configPath := filepath.Join(sshDir, "config")
+	configContent := strings.Join(configEntries, "")
+	if err := ioutil.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		return err
+	}
+	knownHostsPath := filepath.Join(sshDir, "known_hosts")
+	knownHostsContent := strings.Join(knownHosts, "\n")
+	return ioutil.WriteFile(knownHostsPath, []byte(knownHostsContent), 0600)
+}
+
+type SSHEntry struct {
+	Name       string
+	PrivateKey string
+	KnownHosts string
+}
+
+func (be *SSHEntry) path(sshDir string) string {
+	return filepath.Join(sshDir, "id_"+be.Name)
+}
+
+func (be *SSHEntry) Write(sshDir string) error {
+	return ioutil.WriteFile(be.path(sshDir), []byte(be.PrivateKey), 0600)
+}
+
+func SSHKeyScan(domain string) ([]byte, error) {
+	c := exec.Command("ssh-keyscan", domain)
+	var output bytes.Buffer
+	c.Stdout = &output
+	c.Stderr = &output
+	if err := c.Run(); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -471,6 +471,7 @@ k8s.io/client-go/rest
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/testing
+k8s.io/client-go/util/jsonpath
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
 k8s.io/client-go/kubernetes/typed/apps/v1
 k8s.io/client-go/kubernetes/typed/apps/v1beta1
@@ -507,7 +508,6 @@ k8s.io/client-go/kubernetes/typed/settings/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1beta1
-k8s.io/client-go/util/jsonpath
 k8s.io/client-go/tools/pager
 k8s.io/client-go/util/retry
 k8s.io/client-go/tools/auth
@@ -520,8 +520,8 @@ k8s.io/client-go/rest/watch
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/transport
 k8s.io/client-go/util/cert
-k8s.io/client-go/tools/reference
 k8s.io/client-go/third_party/forked/golang/template
+k8s.io/client-go/tools/reference
 k8s.io/client-go/tools/clientcmd/api/v1
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1


### PR DESCRIPTION
Processing largely follows the Tekton design.  Resources (cluster, git, etc) are similar (in coding and design) - at least until we have a cleaner design in place.  /workspace is the default directory, and resources are created in this context (although in general, these can be changed).

This functionality was initially meant to be generic and consistent across task images and the task interface, as opposed to being specific to each task image.  Originally the idea was to build this to ensure it was easy to leverage from custom images written by customers (and to use basic scripting rather than `go`).  We may want to transition this internally to use `go` instead, similar to the `kops` functionality, but this is debatable.  The entrypoint scripts are already getting a bit unwieldy trying to cover multiple scenarios.

Naming and spec definition should probably be cleaned up and standardized.

Testing and error handling needs fleshed out still.

