### PR TITLE
Adding kaniko task image

### DIFF
--- a/cmd/nebula-kaniko/Dockerfile.include
+++ b/cmd/nebula-kaniko/Dockerfile.include
@@ -1,0 +1,21 @@
+FROM gcr.io/kaniko-project/executor:latest as base
+
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/__OUTPUTBIN__ /usr/bin/__OUTPUTBIN__
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/ni /usr/bin/ni
+RUN apk update && apk --no-cache add git gcc bind-dev musl-dev ca-certificates curl jq openssh openssl && update-ca-certificates
+
+COPY --from=base /kaniko /kaniko
+
+ENV PATH "$PATH:/kaniko"
+ENV SSL_CERT_DIR=/kaniko/ssl/certs
+ENV DOCKER_CONFIG /kaniko/.docker/
+ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
+
+COPY ./cmd/nebula-kaniko/content /nebula
+
+RUN ["docker-credential-gcr", "config", "--token-source=env"]
+
+WORKDIR /nebula
+ENTRYPOINT ["/nebula/run.sh"]

--- a/cmd/nebula-kaniko/build-info.sh
+++ b/cmd/nebula-kaniko/build-info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CMD="nebula-kaniko"
+DOCKER_REPO="projectnebula/kaniko"

--- a/cmd/nebula-kaniko/content/run.sh
+++ b/cmd/nebula-kaniko/content/run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+export GOOGLE_APPLICATION_CREDENTIALS=/workspace/credentials.json
+
+ni git clone
+ni credentials config
+
+NAME=$(ni get -p {.git.name})
+DOCKERFILE=$(ni get -p {.git.dockerfile})
+DESTINATION=$(ni get -p {.destination})
+
+WORKSPACE=/workspace/${NAME}
+DOCKERFILE=${WORKSPACE}/${DOCKERFILE:-Dockerfile}
+
+/kaniko/executor --dockerfile=${DOCKERFILE} --context=${WORKSPACE} --destination=${DESTINATION}

--- a/cmd/nebula-kaniko/main.go
+++ b/cmd/nebula-kaniko/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "os"
+
+func main() {
+	os.Exit(0)
+}


### PR DESCRIPTION
Primarily built to work with GCR.  Would need additional work to support other docker registries.

Does not currently work within our restricted Nebula clusters.  Fairly confident this is due to permissions, but this has not been looked into again.