### PR TITLE
Adding vault task image

### DIFF
--- a/cmd/nebula-vault/Dockerfile.include
+++ b/cmd/nebula-vault/Dockerfile.include
@@ -1,0 +1,10 @@
+FROM vault:latest
+
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/__OUTPUTBIN__ /usr/bin/__OUTPUTBIN__
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/ni /usr/bin/ni
+RUN apk update && apk --no-cache add git gcc bind-dev musl-dev ca-certificates curl jq openssh openssl && update-ca-certificates
+
+COPY ./cmd/nebula-vault/content /nebula
+
+WORKDIR /nebula
+ENTRYPOINT ["/nebula/run.sh"]

--- a/cmd/nebula-vault/build-info.sh
+++ b/cmd/nebula-vault/build-info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CMD="nebula-vault"
+DOCKER_REPO="projectnebula/vault"

--- a/cmd/nebula-vault/content/run.sh
+++ b/cmd/nebula-vault/content/run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+export VAULT_ADDR=$(ni get -p {.vault.url})
+
+COMMAND=$(ni get -p {.command})
+ARGS=$(ni get -p {.args})
+
+GIT=$(ni get -p {.git})
+if [ -n "${GIT}" ]; then
+    ni git clone
+    NAME=$(ni get -p {.git.name})
+    WORKSPACE_PATH=/workspace/${NAME}
+    cd ${WORKSPACE_PATH}
+fi
+
+TOKEN=$(ni get -p {.vault.token})
+if [ -n "${TOKEN}" ]; then
+    vault login ${TOKEN}
+fi
+
+vault ${COMMAND} ${ARGS}

--- a/cmd/nebula-vault/main.go
+++ b/cmd/nebula-vault/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "os"
+
+func main() {
+	os.Exit(0)
+}


### PR DESCRIPTION
Originally custom-built to enable end-to-end Nebula provisioning, as there was a need to support a wide variety of complex vault commands that were intertwined with `kubectl` commands.  Avoiding that additional complexity in the base image for now.  May need further review.