### PR TITLE
Adding (base) helm task image

### DIFF
--- a/cmd/nebula-helm/Dockerfile.include
+++ b/cmd/nebula-helm/Dockerfile.include
@@ -1,0 +1,10 @@
+FROM alpine/helm:2.13.1
+
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/__OUTPUTBIN__ /usr/bin/__OUTPUTBIN__
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/ni /usr/bin/ni
+RUN apk update && apk --no-cache add git gcc bind-dev musl-dev ca-certificates curl jq openssh openssl && update-ca-certificates
+
+COPY ./cmd/nebula-helm/content /nebula
+
+WORKDIR /nebula
+ENTRYPOINT ["/nebula/run.sh"]

--- a/cmd/nebula-helm/build-info.sh
+++ b/cmd/nebula-helm/build-info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CMD="nebula-helm"
+DOCKER_REPO="projectnebula/helm"

--- a/cmd/nebula-helm/content/run.sh
+++ b/cmd/nebula-helm/content/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+ni cluster config
+
+NS=$(ni get -p {.namespace})
+CLUSTER=$(ni get -p {.cluster.name})
+
+KUBECONFIG=/workspace/${CLUSTER}/kubeconfig
+
+COMMAND=$(ni get -p {.command})
+ARGS=$(ni get -p {.args})
+
+helm init --client-only
+helm ${COMMAND} ${ARGS} --namespace ${NS} --kubeconfig ${KUBECONFIG}

--- a/cmd/nebula-helm/main.go
+++ b/cmd/nebula-helm/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "os"
+
+func main() {
+	os.Exit(0)
+}


### PR DESCRIPTION
Generic, base helm image (as opposed to `nebula-helm-deployer`, which has more specific context).

Note the same issue with supporting multiple helm versions, which we do not have a design for currently.

We're avoiding basing our own internal images off other internal images for now, as this has multiple concerns with versioning.

We need to revisit how we expect commands and arguments to be cleanly represented in the `spec`.  Currently, this requires specifying basic `command` and `args`, with custom use cases added (over time) for specific commands.