### PR TITLE
Adding kustomize image

### DIFF
--- a/cmd/nebula-kustomize/Dockerfile.include
+++ b/cmd/nebula-kustomize/Dockerfile.include
@@ -1,0 +1,14 @@
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/__OUTPUTBIN__ /usr/bin/__OUTPUTBIN__
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/ni /usr/bin/ni
+RUN apk update && apk --no-cache add git gcc bind-dev musl-dev ca-certificates curl jq openssh openssl && update-ca-certificates
+
+ENV KUBE_LATEST_VERSION="v1.15.0"
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+COPY ./cmd/nebula-kustomize/content /nebula
+
+WORKDIR /nebula
+ENTRYPOINT ["/nebula/run.sh"]

--- a/cmd/nebula-kustomize/build-info.sh
+++ b/cmd/nebula-kustomize/build-info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CMD="nebula-kustomize"
+DOCKER_REPO="projectnebula/kustomize"

--- a/cmd/nebula-kustomize/content/run.sh
+++ b/cmd/nebula-kustomize/content/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+NS=$(ni get -p {.namespace})
+CLUSTER=$(ni get -p {.cluster.name})
+KUBECONFIG=/workspace/${CLUSTER}/kubeconfig
+
+ni cluster config
+
+PATH=$(ni get -p {.path})
+WORKSPACE_PATH=${PATH}
+
+GIT=$(ni get -p {.git})
+if [ -n "${GIT}" ]; then
+    ni git clone
+    NAME=$(ni get -p {.git.name})
+    WORKSPACE_PATH=/workspace/${NAME}/${PATH}
+fi
+
+kubectl kustomize ${WORKSPACE_PATH}
+kubectl apply -k ${WORKSPACE_PATH} --namespace ${NS} --kubeconfig ${KUBECONFIG}

--- a/cmd/nebula-kustomize/main.go
+++ b/cmd/nebula-kustomize/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "os"
+
+func main() {
+	os.Exit(0)
+}


### PR DESCRIPTION
Currently based off of the integrated version of kustomize in kubectl.  This may need further evaluation, per common version use (of kustomize/kubectl).  Standalone kustomize image has already been prototyped as well, so this would not represent a blocker.

More robust support (for handling multiple base/overlay directories, for example) will likely need added in the future.