### PR TITLE
Adding ECS images

### DIFF
--- a/cmd/nebula-ecs-deployer/Dockerfile.include
+++ b/cmd/nebula-ecs-deployer/Dockerfile.include
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/__OUTPUTBIN__ /usr/bin/__OUTPUTBIN__
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/ni /usr/bin/ni
+RUN apk update && apk --no-cache add git gcc bind-dev musl-dev ca-certificates curl jq openssh openssl && update-ca-certificates
+
+RUN curl -L https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest -o /usr/local/bin/ecs-cli \
+ && chmod +x /usr/local/bin/ecs-cli
+
+COPY ./cmd/nebula-ecs-deployer/content /nebula
+
+WORKDIR /nebula
+ENTRYPOINT ["/nebula/run.sh"]

--- a/cmd/nebula-ecs-deployer/build-info.sh
+++ b/cmd/nebula-ecs-deployer/build-info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CMD="nebula-ecs-deployer"
+DOCKER_REPO="projectnebula/ecs-deployer"

--- a/cmd/nebula-ecs-deployer/content/run.sh
+++ b/cmd/nebula-ecs-deployer/content/run.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+CREDENTIALS=$(ni get -p {.credentials})
+if [ -n "${CREDENTIALS}" ]; then
+    ni credentials config
+    export AWS_SHARED_CREDENTIALS_FILE=/workspace/credentials
+fi
+
+PATH=$(ni get -p {.path})
+WORKSPACE_PATH=${PATH}
+
+GIT=$(ni get -p {.git})
+if [ -n "${GIT}" ]; then
+    ni git clone
+    NAME=$(ni get -p {.git.name})
+    WORKSPACE_PATH=/workspace/${NAME}/${PATH}
+fi
+
+cd ${WORKSPACE_PATH}
+
+CLUSTER=$(ni get -p {.cluster.name})
+REGION=$(ni get -p {.cluster.region})
+
+ecs-cli compose --project-name ${CLUSTER} service up --cluster ${CLUSTER} --cluster-config ${CLUSTER} --launch-type FARGATE --region ${REGION}

--- a/cmd/nebula-ecs-deployer/main.go
+++ b/cmd/nebula-ecs-deployer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	os.Exit(0)
+}

--- a/cmd/nebula-ecs-provisioner/Dockerfile.include
+++ b/cmd/nebula-ecs-provisioner/Dockerfile.include
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/__OUTPUTBIN__ /usr/bin/__OUTPUTBIN__
+COPY --from=builder /go/src/github.com/puppetlabs/nebula-tasks/ni /usr/bin/ni
+RUN apk update && apk --no-cache add git gcc bind-dev musl-dev ca-certificates curl jq openssh openssl && update-ca-certificates
+
+RUN curl -L https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest -o /usr/local/bin/ecs-cli \
+ && chmod +x /usr/local/bin/ecs-cli
+
+COPY ./cmd/nebula-ecs-provisioner/content /nebula
+
+WORKDIR /nebula
+ENTRYPOINT ["/nebula/run.sh"]

--- a/cmd/nebula-ecs-provisioner/build-info.sh
+++ b/cmd/nebula-ecs-provisioner/build-info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CMD="nebula-ecs-provisioner"
+DOCKER_REPO="projectnebula/ecs-provisioner"

--- a/cmd/nebula-ecs-provisioner/content/run.sh
+++ b/cmd/nebula-ecs-provisioner/content/run.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+CREDENTIALS=$(ni get -p {.credentials})
+if [ -n "${CREDENTIALS}" ]; then
+    ni credentials config
+    export AWS_SHARED_CREDENTIALS_FILE=/workspace/credentials
+fi
+
+PATH=$(ni get -p {.path})
+WORKSPACE_PATH=${PATH}
+
+GIT=$(ni get -p {.git})
+if [ -n "${GIT}" ]; then
+    ni git clone
+    NAME=$(ni get -p {.git.name})
+    WORKSPACE_PATH=/workspace/${NAME}/${PATH}
+fi
+
+cd ${WORKSPACE_PATH}
+
+CLUSTER=$(ni get -p {.cluster.name})
+REGION=$(ni get -p {.cluster.region})
+
+ecs-cli configure --cluster ${CLUSTER} --default-launch-type FARGATE --config-name ${CLUSTER} --region ${REGION}
+ecs-cli up --cluster-config ${CLUSTER}

--- a/cmd/nebula-ecs-provisioner/main.go
+++ b/cmd/nebula-ecs-provisioner/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	os.Exit(0)
+}


### PR DESCRIPTION
This is just scratching the surface of ECS, but this is already a nice, functional addition.

Note that currently between provisioning and deployment, several manual configuration steps would generally have to be performed, as it requires output from the cluster creation (and other subsequent commands) to be used.

Once we have a design around retrieving/passing output, we may be able to handle this holistically (at the very least with a more comprehensive set of default commands).