### PR TITLE
Env bash and sed arguments

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -32,9 +32,9 @@ build_image() {
     cp scripts/Dockerfile.template "${docker_file}"
     cat "${include}" >> "${docker_file}"
 
-    sed -i "s|__OUTPUTBIN__|${command_name}|g" "${docker_file}"
-    sed -i "s|__GOMAIN__|./cmd/${command_name}|g" "${docker_file}"
-    sed -i "s|__DOCKER_CMD__|${DOCKER_CMD}|g" "${docker_file}"
+    sed -i.bak -e "s|__OUTPUTBIN__|${command_name}|g" "${docker_file}"
+    sed -i.bak -e "s|__GOMAIN__|./cmd/${command_name}|g" "${docker_file}"
+    sed -i.bak -e "s|__DOCKER_CMD__|${DOCKER_CMD}|g" "${docker_file}"
 
     docker build -f "${docker_file}" -t "${DOCKER_REPO}:${VERSION}" .
 

--- a/scripts/build-info.sh
+++ b/scripts/build-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export RELEASE_MANIFEST=ci-release-manifest
 export TRAVIS_BRANCH="${TRAVIS_BRANCH:-$(git branch | grep \* | cut -d ' ' -f2)}"

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [ -z "${NEBULA_EMAIL:-}" ] || [ -z "${NEBULA_PASSWORD:-}" ] || [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${NEBULA_WORKFLOW:-}" ] || [ -z "${VERSION:-}" ] || [ "${NO_DOCKER_PUSH:-}" == "yes" ]; then

--- a/scripts/generate
+++ b/scripts/generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/release
+++ b/scripts/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 release_docker_images() {
     if [ -n "${RELEASE_MANIFEST}" ] && [ "${NO_DOCKER_PUSH}" != "yes" ]; then

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 go_test() {
     go test -race -mod=vendor ./...


### PR DESCRIPTION
MacOS ships with bash 3 at /bin/bash and rootless security blocks
modifying this binary without shenanigans. Homebrew can install bash 5
but it is in /usr/local/bin/bash . And it's a nice practice to use
/usr/bin/env in shebangs anyway.

BSD sed's -i argument takes a non-optional "extension" to postfix the
file during in-place modification before replacing the original file.
Passing an empty value for this works.

It's also nice practice to add -e for the expression.