### PR TITLE
cleans and clears up the use of vault in the controller and metadata api

### DIFF
--- a/cmd/nebula-metadata-api/main.go
+++ b/cmd/nebula-metadata-api/main.go
@@ -25,21 +25,24 @@ func main() {
 	vaultRole := flag.String("vault-role", "", "The role to use when logging into the vault server")
 	serviceAccountTokenPath := flag.String("service-account-token-path",
 		defaultServiceAccountTokenPath, "The path to k8s pod service account token")
-	workflowID := flag.String("workflow-id", "", "The id of the workflow these secrets are scoped to")
-	vaultEngineMount := flag.String("vault-engine-mount", "nebula", "The engine mount to use when crafting secret paths")
+	scopedSecretsPath := flag.String("scoped-secrets-path", "", "The path to use when crafting secret paths")
 	namespace := flag.String("namespace", "", "The kubernetes namespace that contains the workflow")
 	devPreConfigPath := flag.String("development-preconfiguration-path", "", "The path to a development preconfiguration file. This option will put the server in development mode and all managers will operate in in-memory mode.")
 
 	flag.Parse()
 
+	if *scopedSecretsPath == "" {
+		fmt.Fprintln(os.Stderr, "server requires a path to scoped secrets (-scoped-secrets-path)")
+		os.Exit(1)
+	}
+
 	cfg := config.MetadataServerConfig{
 		BindAddr:                   *bindAddr,
 		VaultAddr:                  *vaultAddr,
 		VaultRole:                  *vaultRole,
-		VaultEngineMount:           *vaultEngineMount,
 		VaultToken:                 *vaultToken,
+		ScopedSecretsPath:          *scopedSecretsPath,
 		K8sServiceAccountTokenPath: *serviceAccountTokenPath,
-		WorkflowID:                 *workflowID,
 		Namespace:                  *namespace,
 		DevelopmentPreConfigPath:   *devPreConfigPath,
 		Logger:                     NewLogger(LoggerOptions{Debug: *debug}),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,14 +15,12 @@ type MetadataServerConfig struct {
 	// Nebula and the metadata-api, this is most-likely the kubernetes namespace
 	// that the workflow is running under.
 	VaultRole string
-	// VaultEngineMount is the store to use inside vault. Added to the path
-	// segment when crafting the path to a secret.
-	VaultEngineMount string
 	// VaultToken is an optional token to use for authenticating with the
 	// vaule server or agent.
 	VaultToken string
-	// WorkflowID is the ID of the workflow to run the metadata-api under
-	WorkflowID string
+	// ScopedSecretsPath is the store to use inside secrets backends. Added to the path
+	// segment when crafting the path to a secret.
+	ScopedSecretsPath string
 	// K8sServiceAccountTokenPath is the path to the Service Account token. This
 	// defaults to the standard kubernetes location that is set when a pod is run.
 	K8sServiceAccountTokenPath string

--- a/pkg/controllers/workflow/manager.go
+++ b/pkg/controllers/workflow/manager.go
@@ -1,11 +1,13 @@
 package workflow
 
 import (
+	"context"
 	"time"
 
 	nebclientset "github.com/puppetlabs/nebula-tasks/pkg/generated/clientset/versioned"
 	nebinformers "github.com/puppetlabs/nebula-tasks/pkg/generated/informers/externalversions"
 	nebv1informers "github.com/puppetlabs/nebula-tasks/pkg/generated/informers/externalversions/nebula.puppet.com/v1"
+	"github.com/puppetlabs/nebula-tasks/pkg/secrets"
 	tekclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	tekinformers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions"
 	pipelinev1alpha1informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
@@ -60,4 +62,9 @@ func NewDependencyManager(kcfg *rest.Config) (*DependencyManager, error) {
 	}
 
 	return d, nil
+}
+
+type SecretAuthAccessManager interface {
+	GrantScopedAccess(ctx context.Context, workflowID, namespace, serviceAccount string) (*secrets.AccessGrant, error)
+	RevokeScopedAccess(ctx context.Context, namespace string) error
 }

--- a/pkg/metadataapi/op/op.go
+++ b/pkg/metadataapi/op/op.go
@@ -36,20 +36,26 @@ type DefaultManagerFactory struct {
 	spm SpecsManager
 }
 
-// SecretsManager creates and returns a new SecretsManager implementation.
+// SecretsManager returns a configured SecretsManager implementation.
+// See pkg/metadataapi/op/secretsmanager.go
 func (m DefaultManagerFactory) SecretsManager() SecretsManager {
 	return m.sm
 }
 
-// OutputsManager creates and returns a new OutputsManager based on values in Configuration type.
+// OutputsManager returns a configured OutputsManager based on values in Configuration type.
+// See pkg/metadataapi/op/outputsmanager.go
 func (m DefaultManagerFactory) OutputsManager() OutputsManager {
 	return m.om
 }
 
+// MetadataManager returns a configured MetadataManager used to get task metadata.
+// See pkg/metadataapi/op/metadatamanager.go
 func (m DefaultManagerFactory) MetadataManager() MetadataManager {
 	return m.mm
 }
 
+// SpecsManager returns a configured SpecsManager.
+// See pkg/metadataapi/op/specsmanager.go
 func (m DefaultManagerFactory) SpecsManager() SpecsManager {
 	return m.spm
 }
@@ -66,8 +72,7 @@ func NewForKubernetes(ctx context.Context, cfg *config.MetadataServerConfig) (*D
 		K8sServiceAccountTokenPath: cfg.K8sServiceAccountTokenPath,
 		Token:                      cfg.VaultToken,
 		Role:                       cfg.VaultRole,
-		Bucket:                     cfg.WorkflowID,
-		EngineMount:                cfg.VaultEngineMount,
+		ScopedSecretsPath:          cfg.ScopedSecretsPath,
 		Logger:                     cfg.Logger,
 	})
 	if err != nil {
@@ -92,6 +97,9 @@ type developmentPreConfig struct {
 	TaskSpecs    map[string]string         `yaml:"taskSpecs"`
 }
 
+// NewForDev returns a new DefaultManagerFactory useful for development and running the metadata api server
+// locally. The manager implementations are mostly non-persistent in-memory storage backends. No data will be written
+// to disk and this should not be used in production.
 func NewForDev(ctx context.Context, cfg *config.MetadataServerConfig) (*DefaultManagerFactory, errors.Error) {
 	var preCfg developmentPreConfig
 

--- a/pkg/secrets/model.go
+++ b/pkg/secrets/model.go
@@ -1,6 +1,14 @@
 package secrets
 
+// Secret is a model that represents the key/value pair for a single secret.
 type Secret struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// AccessGrant is a model that contains the metadata for accessing
+// Scoped secrets.
+type AccessGrant struct {
+	BackendAddr string
+	ScopedPath  string
 }

--- a/pkg/secrets/vault/config.go
+++ b/pkg/secrets/vault/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	// The bucket path segment we are proxying requests for secrets for
 	Bucket string
 	// The engine to use to form paths from
-	EngineMount string
-	Logger      logging.Logger
+	EngineMount       string
+	ScopedSecretsPath string
+	Logger            logging.Logger
 }

--- a/pkg/secrets/vault/vault.go
+++ b/pkg/secrets/vault/vault.go
@@ -52,7 +52,7 @@ func (v *vaultLoggedInClient) read(path string) (*vaultapi.Secret, error) {
 
 // mountPath returns a vault-api style path to the secret
 func (v *vaultLoggedInClient) mountPath(key string) string {
-	return path.Join(v.cfg.EngineMount, "data", "workflows", v.cfg.Bucket, key)
+	return path.Join(v.cfg.ScopedSecretsPath, key)
 }
 
 // extractValue fetches the secret value from the secretRef key (standard location for nebula


### PR DESCRIPTION
- merges calls to grant and revoke secret access making cleanup and garbage
collection a little bit easier in the controller after a pipeline run
has concluded.
 
There are still a few more things to do to hide direct vault use from the controller, but this is a start. It reduces calls into the "secrets backend" and combines those calls into Grant and Revoke methods that take fewer arguments.