### PR TITLE
Push containers for :latest usage via master branch

### DIFF
--- a/scripts/build-info.sh
+++ b/scripts/build-info.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
 export TRAVIS_BRANCH="${TRAVIS_BRANCH:-$(git branch | grep \* | cut -d ' ' -f2)}"
+export TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST:-}"
 export TRAVIS_EVENT_TYPE="${TRAVIS_EVENT_TYPE:-}"
 export NEBULA_TASKS_BUILD_DIR="${NEBULA_TASKS_BUILD_DIR:-.build}"
 export NEBULA_TASKS_RELEASE_MANIFEST="${NEBULA_TASKS_RELEASE_MANIFEST:-${NEBULA_TASKS_BUILD_DIR}/ci-release-manifest}"
+
+export NEBULA_TASKS_RELEASE_LATEST=
+[ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] && export NEBULA_TASKS_RELEASE_LATEST=true
 
 DIRTY=
 [ -n "$(git status --porcelain --untracked-files=no)" ] && DIRTY="-dirty"

--- a/scripts/release
+++ b/scripts/release
@@ -4,8 +4,13 @@ release_docker_images() {
     if [ -n "${NEBULA_TASKS_RELEASE_MANIFEST}" ] && [ "${NO_DOCKER_PUSH}" != "yes" ]; then
         gcloud auth configure-docker || fail "gcloud authentication was not configured correctly"
 
-        for repo in $(cat "${NEBULA_TASKS_RELEASE_MANIFEST}"); do
-            docker push "${repo}" || fail "failed to push to the docker repository"
+        for repo_tag in $(cat "${NEBULA_TASKS_RELEASE_MANIFEST}"); do
+            IFS=':' read -r REPO TAG <<<"${repo_tag}"
+            docker push "${REPO}:${TAG}" || fail "failed to push to the docker repository"
+            if [ "${NEBULA_TASKS_RELEASE_LATEST}" = "true" ]; then
+                docker tag "${REPO}:${TAG}" "${REPO}"
+                docker push "${REPO}" || fail "failed to push to the docker repository"
+            fi
         done
     else
         echo "docker images were created, but not pushed"


### PR DESCRIPTION
Latest isn't a real tag; it just means the latest container without a
tag.

Travis doesn't have a way of exposing the "build branch" to the
environment (see https://github.com/travis-ci/travis-ci/issues/6652) so
the build scripts can't detect a merge to master.

Travis also doesn't have a way of doing "conditional environment variables"
but does have conditional stages based on the branch. But for pull
requests this is the "base branch." We don't want to release latest from
pull request builds.

Travis does expose an environment variable indicating whether it is a PR
build or a merge build, as per https://docs.travis-ci.com/user/pull-requests/