### PR TITLE
WorkflowController improvements

### DIFF
--- a/pkg/util/slug.go
+++ b/pkg/util/slug.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"math"
+	"regexp"
+	"strings"
+)
+
+var (
+	slugexp   = regexp.MustCompile(`[^\w\s]+`)
+	spacesexp = regexp.MustCompile(`\s+`)
+)
+
+func Slug(name string) string {
+	slg := spacesexp.ReplaceAllString(strings.ToLower(strings.TrimSpace(name)), "-")
+	slg = slugexp.ReplaceAllString(slg, "-")
+
+	len := float64(len(slg))
+	maxLen := math.Min(len, 63)
+
+	return strings.Trim(slg[0:int(maxLen)], "-")
+}


### PR DESCRIPTION
- Log annotations are now added to the associated WorkflowRun and PipelineRun
- Log annotations will be removed from the PipelineRun later (after the API no longer uses these)
- Moved the `metadata-api` readiness validation to after the WorkflowRun is created, but before the PipelineRun is created.  This will be further refined in the future.  Currently, by the time the SecretAuth and WorkflowRun are queued/processed, the `metadata-api` will be ready.
- Added the timeout value explicitly to the http client; previously, this would often wait for the default 30 second timeout.
- Explicitly check the endpoint addresses first, as it may already exist and may never receive watch events (this happens frequently when it times out the first time, and requeues later)
- Do not abort prematurely if errors occur when uploading one individual log file (which also prevents the cleanup of unrelated resources).  Error handling will need revisited for this later.
- Updated log annotations names to comply with naming standards.
- Overall rework and refinement will be done later, as this code is expected to change.