### PR TITLE
Conditions should short-circuit on any failure

### DIFF
--- a/pkg/metadataapi/server/api/conditions_test.go
+++ b/pkg/metadataapi/server/api/conditions_test.go
@@ -72,6 +72,44 @@ func TestGetConditions(t *testing.T) {
 				`resolve: parameter "param1" could not be found`,
 			}),
 		},
+		{
+			Name: "Condition type error",
+			Conditions: []interface{}{
+				"foobar",
+				"fubar",
+			},
+			ExpectedError: errors.NewConditionTypeError(
+				`string`,
+			),
+		},
+		{
+			Name: "Short-circuit failure ordering variant 1 (failure first)",
+			Conditions: []interface{}{
+				sdktestutil.JSONInvocation("equals", []interface{}{
+					sdktestutil.JSONOutput("previous-task", "output1"),
+					"fubar",
+				}),
+				sdktestutil.JSONInvocation("equals", []interface{}{
+					sdktestutil.JSONParameter("param1"),
+					"fubar",
+				}),
+			},
+			ExpectedSuccess: false,
+		},
+		{
+			Name: "Short-circuit failure ordering variant 2 (unresolvable first)",
+			Conditions: []interface{}{
+				sdktestutil.JSONInvocation("equals", []interface{}{
+					sdktestutil.JSONParameter("param1"),
+					"fubar",
+				}),
+				sdktestutil.JSONInvocation("equals", []interface{}{
+					sdktestutil.JSONOutput("previous-task", "output1"),
+					"fubar",
+				}),
+			},
+			ExpectedSuccess: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
Condition logic will now return failure if any resolved values are false, regardless of the presence of any unknown/unresolvable values. This is primarily aimed at conditions using both discrete values (such as parameters or outputs) and external input data that may require waiting (such as approvals). However, this just as significantly applies to outputs alone, as any given step may fail-fast with only a subset of outputs defined rather than an expected set. By default, we don't want to support waiting until all the data is present first; for context, conditions are not applied until a step/task has all of its dependencies met (although I don't really think that makes any difference, regardless) and outputs currently guarantee dependencies as well.

We may want to consider expanding the context and handling later to specify the exact state and unresolved values in all cases (although this would only likely ever be useful for informational purposes only).