### PR TITLE
Propagate tenant changes to dependent objects

### DIFF
--- a/manifests/resources/relay.sh_tenants.yaml
+++ b/manifests/resources/relay.sh_tenants.yaml
@@ -121,6 +121,10 @@ spec:
               x-kubernetes-list-map-keys:
               - type
               x-kubernetes-list-type: map
+            namespace:
+              description: Namespace is the namespace managed by this tenant or the
+                namespace of the tenant if it is unmanaged.
+              type: string
             observedGeneration:
               description: ObservedGeneration is the generation of the resource specification
                 that this status matches.

--- a/manifests/resources/relay.sh_webhooktriggers.yaml
+++ b/manifests/resources/relay.sh_webhooktriggers.yaml
@@ -113,6 +113,10 @@ spec:
               x-kubernetes-list-map-keys:
               - type
               x-kubernetes-list-type: map
+            namespace:
+              description: Namespace is the Kubernetes namespace containing the target
+                resources of this webhook trigger.
+              type: string
             observedGeneration:
               description: ObservedGeneration is the generation of the resource specification
                 that this status matches.

--- a/pkg/apis/relay.sh/v1beta1/tenant_types.go
+++ b/pkg/apis/relay.sh/v1beta1/tenant_types.go
@@ -93,6 +93,12 @@ type TenantStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// Namespace is the namespace managed by this tenant or the namespace of the
+	// tenant if it is unmanaged.
+	//
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// Conditions are the observations of this resource's state.
 	//
 	// +optional

--- a/pkg/apis/relay.sh/v1beta1/trigger_types.go
+++ b/pkg/apis/relay.sh/v1beta1/trigger_types.go
@@ -60,6 +60,12 @@ type WebhookTriggerStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// Namespace is the Kubernetes namespace containing the target resources of
+	// this webhook trigger.
+	//
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// URL is the endpoint for the webhook once provisioned.
 	//
 	// +optional

--- a/pkg/controller/handler/enqueue_namelabel.go
+++ b/pkg/controller/handler/enqueue_namelabel.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	EnqueueRequestForReferencesByNameLabelTimeout = 30 * time.Second
+)
+
+type EnqueueRequestForReferencesByNameLabel struct {
+	Label      string
+	TargetType runtime.Object
+	gvk        schema.GroupVersionKind
+	cl         client.Client
+}
+
+var _ handler.EventHandler = &EnqueueRequestForReferencesByNameLabel{}
+var _ inject.Client = &EnqueueRequestForReferencesByNameLabel{}
+var _ inject.Scheme = &EnqueueRequestForReferencesByNameLabel{}
+
+func (e *EnqueueRequestForReferencesByNameLabel) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Meta, q)
+}
+
+func (e *EnqueueRequestForReferencesByNameLabel) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.MetaOld, q)
+	e.add(evt.MetaNew, q)
+}
+
+func (e *EnqueueRequestForReferencesByNameLabel) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Meta, q)
+}
+
+func (e *EnqueueRequestForReferencesByNameLabel) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Meta, q)
+}
+
+func (e *EnqueueRequestForReferencesByNameLabel) add(target metav1.Object, q workqueue.RateLimitingInterface) {
+	ctx, cancel := context.WithTimeout(context.Background(), EnqueueRequestForReferencesByNameLabelTimeout)
+	defer cancel()
+
+	var objs unstructured.UnstructuredList
+	objs.SetGroupVersionKind(e.gvk)
+
+	if err := e.cl.List(ctx, &objs, client.InNamespace(target.GetNamespace()), client.MatchingLabels{e.Label: target.GetName()}); err != nil {
+		klog.Errorf("enqueue: failed to list resources referencing %s %s/%s by label: %+v", e.gvk, target.GetNamespace(), target.GetName(), err)
+
+		// No choice but to panic here. Missing this reconcile could mean that
+		// downstream dependencies don't get updated, so we'll try to restart
+		// the whole process.
+		panic(err)
+	}
+
+	for _, obj := range objs.Items {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      obj.GetName(),
+			},
+		}
+		q.Add(req)
+		klog.V(4).Infof("enqueue: successful enqueue of %s %s", e.gvk, req.NamespacedName)
+	}
+}
+
+func (e *EnqueueRequestForReferencesByNameLabel) InjectClient(cl client.Client) error {
+	e.cl = cl
+	return nil
+}
+
+func (e *EnqueueRequestForReferencesByNameLabel) InjectScheme(s *runtime.Scheme) error {
+	kinds, _, err := s.ObjectKinds(e.TargetType)
+	if err != nil {
+		return err
+	}
+
+	e.gvk = kinds[0]
+	return nil
+}

--- a/pkg/controller/trigger/controller.go
+++ b/pkg/controller/trigger/controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/puppetlabs/relay-core/pkg/controller/handler"
 	"github.com/puppetlabs/relay-core/pkg/dependency"
 	"github.com/puppetlabs/relay-core/pkg/errmark"
+	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/puppetlabs/relay-core/pkg/reconciler/filter"
 	"github.com/puppetlabs/relay-core/pkg/reconciler/trigger"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -22,6 +23,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler, cfg *config.WorkflowContro
 			MaxConcurrentReconciles: cfg.MaxConcurrentReconciles,
 		}).
 		For(&relayv1beta1.WebhookTrigger{}).
+		Watches(&source.Kind{Type: &relayv1beta1.Tenant{}}, &handler.EnqueueRequestForReferencesByNameLabel{
+			Label:      model.RelayControllerTenantNameLabel,
+			TargetType: &relayv1beta1.WebhookTrigger{},
+		}).
 		Watches(&source.Kind{Type: &servingv1.Service{}}, &handler.EnqueueRequestForAnnotatedDependent{OwnerType: &relayv1beta1.WebhookTrigger{}}).
 		Complete(filter.ChainRight(r,
 			filter.ErrorCaptureReconcilerLink(

--- a/pkg/errmark/errmark.go
+++ b/pkg/errmark/errmark.go
@@ -69,3 +69,7 @@ func IfAll(err error, conds []IfFunc, fn func(err error)) {
 
 	fn(Resolve(err))
 }
+
+func Is(candidate, wanted error) bool {
+	return AsMarkedError(candidate).Delegate == wanted
+}

--- a/pkg/errmark/transient.go
+++ b/pkg/errmark/transient.go
@@ -12,6 +12,20 @@ func TransientRuleExact(err, want error) bool {
 	return err == want
 }
 
+func TransientAll(rules ...TransientRule) TransientRule {
+	return func(err error) bool {
+		for _, rule := range rules {
+			if !rule(err) {
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+var TransientAlways = TransientAll()
+
 func TransientAny(rules ...TransientRule) TransientRule {
 	return func(err error) bool {
 		for _, rule := range rules {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -14,6 +14,7 @@ const (
 	RelayControllerTokenHashAnnotation    = "controller.relay.sh/token-hash"
 	RelayControllerDependencyOfAnnotation = "controller.relay.sh/dependency-of"
 
+	RelayControllerTenantNameLabel       = "controller.relay.sh/tenant-name"
 	RelayControllerTenantWorkloadLabel   = "controller.relay.sh/tenant-workload"
 	RelayControllerWorkflowRunIDLabel    = "controller.relay.sh/run-id"
 	RelayControllerWebhookTriggerIDLabel = "controller.relay.sh/webhook-trigger-id"

--- a/pkg/obj/tenant.go
+++ b/pkg/obj/tenant.go
@@ -170,6 +170,7 @@ func ConfigureTenant(t *Tenant, td *TenantDepsResult) {
 
 	t.Object.Status = relayv1beta1.TenantStatus{
 		ObservedGeneration: t.Object.GetGeneration(),
+		Namespace:          td.TenantDeps.Namespace.Name,
 		Conditions: []relayv1beta1.TenantCondition{
 			{
 				Condition: *conds[relayv1beta1.TenantNamespaceReady],

--- a/pkg/obj/util.go
+++ b/pkg/obj/util.go
@@ -164,20 +164,26 @@ func IsDependencyOf(target metav1.ObjectMeta, owner Owner) (bool, error) {
 	return accessor.GetUID() == dep.UID && accessor.GetNamespace() == dep.Namespace && accessor.GetName() == dep.Name, nil
 }
 
-func Annotate(target *metav1.ObjectMeta, name, value string) {
+func Annotate(target *metav1.ObjectMeta, name, value string) bool {
 	if target.Annotations == nil {
 		target.Annotations = make(map[string]string)
+	} else if candidate, ok := target.Annotations[name]; ok && candidate == value {
+		return false
 	}
 
 	target.Annotations[name] = value
+	return true
 }
 
-func Label(target *metav1.ObjectMeta, name, value string) {
+func Label(target *metav1.ObjectMeta, name, value string) bool {
 	if target.Labels == nil {
 		target.Labels = make(map[string]string)
+	} else if candidate, ok := target.Labels[name]; ok && candidate == value {
+		return false
 	}
 
 	target.Labels[name] = value
+	return true
 }
 
 func CopyLabelsAndAnnotations(target *metav1.ObjectMeta, src metav1.ObjectMeta) {

--- a/pkg/obj/webhooktrigger.go
+++ b/pkg/obj/webhooktrigger.go
@@ -146,7 +146,16 @@ func ConfigureWebhookTrigger(wt *WebhookTrigger, ksr *KnativeServiceResult) {
 		},
 	}
 
-	if ksr.KnativeService != nil && ksr.KnativeService.Object.Status.IsReady() && ksr.KnativeService.Object.Status.URL != nil {
-		wt.Object.Status.URL = ksr.KnativeService.Object.Status.URL.String()
+	if ksr.KnativeService != nil {
+		wt.Object.Status.Namespace = ksr.KnativeService.Key.Namespace
+
+		if ksr.KnativeService.Object.Status.IsReady() && ksr.KnativeService.Object.Status.URL != nil {
+			wt.Object.Status.URL = ksr.KnativeService.Object.Status.URL.String()
+		} else {
+			wt.Object.Status.URL = ""
+		}
+	} else {
+		wt.Object.Status.Namespace = ""
+		wt.Object.Status.URL = ""
 	}
 }

--- a/pkg/reconciler/tenant/reconciler.go
+++ b/pkg/reconciler/tenant/reconciler.go
@@ -55,6 +55,12 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error)
 		return ctrl.Result{}, err
 	}
 
+	if _, err := deps.DeleteStale(ctx, r.Client); err != nil {
+		return ctrl.Result{}, errmark.MapLast(err, func(err error) error {
+			return fmt.Errorf("failed to delete stale dependencies: %+v", err)
+		})
+	}
+
 	obj.ConfigureTenantDeps(ctx, deps)
 
 	tdr := obj.AsTenantDepsResult(deps, deps.Persist(ctx, r.Client))

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -1,0 +1,71 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	relayv1beta1 "github.com/puppetlabs/relay-core/pkg/apis/relay.sh/v1beta1"
+	"github.com/puppetlabs/relay-core/pkg/util/retry"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WaitForTenant(t *testing.T, ctx context.Context, tn *relayv1beta1.Tenant) {
+	require.NoError(t, retry.Retry(ctx, 500*time.Millisecond, func() *retry.RetryError {
+		if err := e2e.ControllerRuntimeClient.Get(ctx, client.ObjectKey{
+			Namespace: tn.GetNamespace(),
+			Name:      tn.GetName(),
+		}, tn); err != nil {
+			return retry.RetryPermanent(err)
+		}
+
+		if tn.GetGeneration() != tn.Status.ObservedGeneration {
+			return retry.RetryTransient(fmt.Errorf("waiting for tenant to reconcile: generation mismatch"))
+		}
+
+		for _, cond := range tn.Status.Conditions {
+			if cond.Type != relayv1beta1.TenantReady {
+				continue
+			} else if cond.Status != corev1.ConditionTrue {
+				break
+			}
+
+			return retry.RetryPermanent(nil)
+		}
+
+		return retry.RetryTransient(fmt.Errorf("waiting for tenant to reconcile: not ready"))
+	}))
+}
+
+func CreateAndWaitForTenant(t *testing.T, ctx context.Context, tn *relayv1beta1.Tenant) {
+	require.NoError(t, e2e.ControllerRuntimeClient.Create(ctx, tn))
+	WaitForTenant(t, ctx, tn)
+}
+
+func Mutate(t *testing.T, ctx context.Context, obj runtime.Object, fn func()) {
+	key, err := client.ObjectKeyFromObject(obj)
+	require.NoError(t, err)
+
+	require.NoError(t, retry.Retry(ctx, 500*time.Millisecond, func() *retry.RetryError {
+		// Mutation function.
+		fn()
+
+		if err := e2e.ControllerRuntimeClient.Update(ctx, obj); errors.IsConflict(err) {
+			// Controller changed object, reload.
+			if err := e2e.ControllerRuntimeClient.Get(ctx, key, obj); err != nil {
+				return retry.RetryPermanent(err)
+			}
+
+			return retry.RetryTransient(err)
+		} else {
+			return retry.RetryPermanent(err)
+		}
+
+		return retry.RetryTransient(nil)
+	}))
+}


### PR DESCRIPTION
This change adds a number of safeguards to ensure tenants and webhook triggers clean up stale data. Namely:

- When a tenant namespace changes, the tenant now deletes the old namespace (if managed) before creating the new namespace.
- Tenant existence is no longer a prerequisite for deleting a webhook trigger.
- When a tenant namespace changes, the webhook trigger now updates its configuration to create a new Knative service in the new namespace.