### PR TITLE
standalone workflow execution support

### DIFF
--- a/cmd/relay-operator/main.go
+++ b/cmd/relay-operator/main.go
@@ -38,6 +38,7 @@ func main() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	environment := fs.String("environment", "dev", "the environment this operator is running in")
+	standalone := fs.Bool("standalone", false, "enables standalone mode which runs workflows without multi-tenant network security protections")
 	kubeconfig := fs.String("kubeconfig", "", "path to kubeconfig file. Only required if running outside of a cluster.")
 	kubeMasterURL := fs.String("kube-master-url", "", "url to the kubernetes master")
 	kubeNamespace := fs.String("kube-namespace", "", "an optional working namespace to restrict to for watching CRDs")
@@ -149,6 +150,7 @@ func main() {
 
 	cfg := &config.WorkflowControllerConfig{
 		Environment:             *environment,
+		Standalone:              *standalone,
 		Namespace:               *kubeNamespace,
 		ImagePullSecret:         *imagePullSecret,
 		MaxConcurrentReconciles: *numWorkers,
@@ -181,6 +183,7 @@ func main() {
 	dm.Manager.GetWebhookServer().Register("/mutate/pod-enforcement", &webhook.Admission{
 		Handler: admission.NewPodEnforcementHandler(
 			admission.PodEnforcementHandlerWithSandboxing(*tenantSandboxing),
+			admission.PodEnforcementHandlerWithStandaloneMode(*standalone),
 		),
 	})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 // configure the Workflow controller.
 type WorkflowControllerConfig struct {
 	Environment             string
+	Standalone              bool
 	Namespace               string
 	ImagePullSecret         string
 	MaxConcurrentReconciles int

--- a/pkg/obj/serviceaccount.go
+++ b/pkg/obj/serviceaccount.go
@@ -112,29 +112,3 @@ func ConfigureUntrustedServiceAccount(sa *ServiceAccount) {
 	// services. It has no permissions.
 	sa.Object.AutomountServiceAccountToken = func(b bool) *bool { return &b }(false)
 }
-
-type systemServiceAccountOptions struct {
-	imagePullSecrets []corev1.LocalObjectReference
-}
-
-type SystemServiceAccountOption func(opts *systemServiceAccountOptions)
-
-func SystemServiceAccountWithImagePullSecret(ref corev1.LocalObjectReference) SystemServiceAccountOption {
-	return func(opts *systemServiceAccountOptions) {
-		opts.imagePullSecrets = append(opts.imagePullSecrets, ref)
-	}
-}
-
-func ConfigureSystemServiceAccount(sa *ServiceAccount, opts ...SystemServiceAccountOption) {
-	// This service account is used by internal containers needing to pull
-	// restricted images.
-
-	sao := &systemServiceAccountOptions{}
-
-	for _, opt := range opts {
-		opt(sao)
-	}
-
-	sa.Object.AutomountServiceAccountToken = func(b bool) *bool { return &b }(false)
-	sa.Object.ImagePullSecrets = sao.imagePullSecrets
-}

--- a/pkg/obj/task.go
+++ b/pkg/obj/task.go
@@ -2,6 +2,7 @@ package obj
 
 import (
 	"context"
+	"fmt"
 
 	nebulav1 "github.com/puppetlabs/relay-core/pkg/apis/nebula.puppet.com/v1"
 	"github.com/puppetlabs/relay-core/pkg/model"
@@ -77,7 +78,7 @@ func ConfigureTask(ctx context.Context, t *Task, wrd *WorkflowRunDeps, ws *nebul
 	}
 
 	if err := wrd.AnnotateStepToken(ctx, &t.Object.ObjectMeta, ws); err != nil {
-		return err
+		return fmt.Errorf("failed to annotate step token: %w", err)
 	}
 
 	t.Object.Spec.Steps = []tektonv1beta1.Step{step}
@@ -144,12 +145,12 @@ func NewTasks(wrd *WorkflowRunDeps) *Tasks {
 
 func ConfigureTasks(ctx context.Context, ts *Tasks) error {
 	if err := ts.Deps.WorkflowRun.Own(ctx, ts); err != nil {
-		return err
+		return fmt.Errorf("failed to own Tasks: %w", err)
 	}
 
 	for i, ws := range ts.Deps.WorkflowRun.Object.Spec.Workflow.Steps {
 		if err := ConfigureTask(ctx, ts.List[i], ts.Deps, ws); err != nil {
-			return err
+			return fmt.Errorf("failed to configure task: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This PR introduces the `-standalone` flag for the relay-operator and uses it to exclude the creation of restrictive resources when running in a single-user environment.