### PR TITLE
Initial environment variable support

### DIFF
--- a/manifests/resources/nebula.puppet.com_workflowruns.yaml
+++ b/manifests/resources/nebula.puppet.com_workflowruns.yaml
@@ -67,6 +67,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      env:
+                        additionalProperties:
+                          description: Unstructured is arbitrary JSON data, which
+                            may also include base64-encoded binary data.
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       image:
                         type: string
                       input:

--- a/pkg/apis/nebula.puppet.com/v1/types.go
+++ b/pkg/apis/nebula.puppet.com/v1/types.go
@@ -57,6 +57,9 @@ type WorkflowStep struct {
 	Args []string `json:"args,omitempty"`
 
 	// +optional
+	Env relayv1beta1.UnstructuredObject `json:"env,omitempty"`
+
+	// +optional
 	When relayv1beta1.Unstructured `json:"when,omitempty"`
 
 	// +optional

--- a/pkg/apis/nebula.puppet.com/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/nebula.puppet.com/v1/zz_generated.deepcopy.go
@@ -244,6 +244,13 @@ func (in *WorkflowStep) DeepCopyInto(out *WorkflowStep) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make(v1beta1.UnstructuredObject, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
+	}
 	in.When.DeepCopyInto(&out.When)
 	if in.DependsOn != nil {
 		in, out := &in.DependsOn, &out.DependsOn

--- a/pkg/manager/builder/metadata.go
+++ b/pkg/manager/builder/metadata.go
@@ -9,6 +9,7 @@ type metadataManagers struct {
 	connections model.ConnectionManager
 	conditions  model.ConditionGetterManager
 	events      model.EventManager
+	environment model.EnvironmentGetterManager
 	parameters  model.ParameterGetterManager
 	secrets     model.SecretManager
 	spec        model.SpecGetterManager
@@ -28,6 +29,10 @@ func (mm *metadataManagers) Conditions() model.ConditionGetterManager {
 
 func (mm *metadataManagers) Events() model.EventManager {
 	return mm.events
+}
+
+func (mm *metadataManagers) Environment() model.EnvironmentGetterManager {
+	return mm.environment
 }
 
 func (mm *metadataManagers) Parameters() model.ParameterGetterManager {
@@ -54,6 +59,7 @@ type MetadataBuilder struct {
 	connections model.ConnectionManager
 	conditions  model.ConditionGetterManager
 	events      model.EventManager
+	environment model.EnvironmentGetterManager
 	parameters  model.ParameterGetterManager
 	secrets     model.SecretManager
 	spec        model.SpecGetterManager
@@ -73,6 +79,11 @@ func (mb *MetadataBuilder) SetConditions(m model.ConditionGetterManager) *Metada
 
 func (mb *MetadataBuilder) SetEvents(m model.EventManager) *MetadataBuilder {
 	mb.events = m
+	return mb
+}
+
+func (mb *MetadataBuilder) SetEnvironment(m model.EnvironmentGetterManager) *MetadataBuilder {
+	mb.environment = m
 	return mb
 }
 
@@ -106,6 +117,7 @@ func (mb *MetadataBuilder) Build() model.MetadataManagers {
 		connections: mb.connections,
 		conditions:  mb.conditions,
 		events:      mb.events,
+		environment: mb.environment,
 		parameters:  mb.parameters,
 		secrets:     mb.secrets,
 		spec:        mb.spec,
@@ -119,6 +131,7 @@ func NewMetadataBuilder() *MetadataBuilder {
 		connections: reject.ConnectionManager,
 		conditions:  reject.ConditionManager,
 		events:      reject.EventManager,
+		environment: reject.EnvironmentManager,
 		parameters:  reject.ParameterManager,
 		secrets:     reject.SecretManager,
 		spec:        reject.SpecManager,

--- a/pkg/manager/configmap/environment.go
+++ b/pkg/manager/configmap/environment.go
@@ -1,0 +1,60 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/puppetlabs/relay-core/pkg/expr/parse"
+	"github.com/puppetlabs/relay-core/pkg/model"
+)
+
+type EnvironmentManager struct {
+	me  model.Action
+	kcm *KVConfigMap
+}
+
+var _ model.EnvironmentManager = &EnvironmentManager{}
+
+func (m *EnvironmentManager) Get(ctx context.Context) (*model.Environment, error) {
+	value, err := m.kcm.Get(ctx, environmentKey(m.me))
+	if err != nil {
+		return nil, err
+	}
+
+	evs := make(map[string]parse.Tree)
+
+	for name, ev := range value.(map[string]interface{}) {
+		evs[name] = parse.Tree(ev)
+	}
+
+	return &model.Environment{
+		Value: evs,
+	}, nil
+}
+
+func (m *EnvironmentManager) Set(ctx context.Context, value map[string]interface{}) (*model.Environment, error) {
+	if err := m.kcm.Set(ctx, environmentKey(m.me), value); err != nil {
+		return nil, err
+	}
+
+	evs := make(map[string]parse.Tree)
+
+	for name, ev := range value {
+		evs[name] = parse.Tree(ev)
+	}
+
+	return &model.Environment{
+		Value: evs,
+	}, nil
+}
+
+func NewEnvironmentManager(action model.Action, cm ConfigMap) *EnvironmentManager {
+	return &EnvironmentManager{
+		me:  action,
+		kcm: NewKVConfigMap(cm),
+	}
+}
+
+func environmentKey(action model.Action) string {
+	return fmt.Sprintf("%s.%s.environment", action.Type().Plural, action.Hash())
+}

--- a/pkg/manager/memory/environment.go
+++ b/pkg/manager/memory/environment.go
@@ -1,0 +1,70 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/puppetlabs/relay-core/pkg/expr/parse"
+	"github.com/puppetlabs/relay-core/pkg/model"
+)
+
+type EnvironmentManager struct {
+	mut sync.RWMutex
+	val *model.Environment
+}
+
+var _ model.EnvironmentManager = &EnvironmentManager{}
+
+func (m *EnvironmentManager) Get(ctx context.Context) (*model.Environment, error) {
+	m.mut.RLock()
+	defer m.mut.RUnlock()
+
+	if m.val == nil {
+		return nil, model.ErrNotFound
+	}
+
+	return m.val, nil
+}
+
+func (m *EnvironmentManager) Set(ctx context.Context, value map[string]interface{}) (*model.Environment, error) {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	evs := make(map[string]parse.Tree)
+
+	for name, ev := range value {
+		evs[name] = parse.Tree(ev)
+	}
+
+	m.val = &model.Environment{
+		Value: evs,
+	}
+
+	return m.val, nil
+}
+
+type EnvironmentManagerOption func(em *EnvironmentManager)
+
+func EnvironmentManagerWithInitialEnvironment(value map[string]interface{}) EnvironmentManagerOption {
+	return func(em *EnvironmentManager) {
+		evs := make(map[string]parse.Tree)
+
+		for name, ev := range value {
+			evs[name] = parse.Tree(ev)
+		}
+
+		em.val = &model.Environment{
+			Value: evs,
+		}
+	}
+}
+
+func NewEnvironmentManager(opts ...EnvironmentManagerOption) *EnvironmentManager {
+	em := &EnvironmentManager{}
+
+	for _, opt := range opts {
+		opt(em)
+	}
+
+	return em
+}

--- a/pkg/manager/reject/environment.go
+++ b/pkg/manager/reject/environment.go
@@ -1,0 +1,19 @@
+package reject
+
+import (
+	"context"
+
+	"github.com/puppetlabs/relay-core/pkg/model"
+)
+
+type environmentManager struct{}
+
+func (*environmentManager) Get(ctx context.Context) (*model.Environment, error) {
+	return nil, model.ErrRejected
+}
+
+func (*environmentManager) Set(ctx context.Context, value map[string]interface{}) (*model.Environment, error) {
+	return nil, model.ErrRejected
+}
+
+var EnvironmentManager model.EnvironmentManager = &environmentManager{}

--- a/pkg/metadataapi/opt/sample.go
+++ b/pkg/metadataapi/opt/sample.go
@@ -42,11 +42,24 @@ func (sp SampleConfigSpec) Interface() map[string]interface{} {
 	return copy
 }
 
+type SampleConfigEnvironment map[string]serialize.YAMLTree
+
+func (sp SampleConfigEnvironment) Interface() map[string]interface{} {
+	copy := make(map[string]interface{})
+
+	for k, v := range sp {
+		copy[k] = v.Tree
+	}
+
+	return copy
+}
+
 type SampleConfigStep struct {
-	Conditions serialize.YAMLTree     `yaml:"conditions"`
-	Spec       SampleConfigSpec       `yaml:"spec"`
-	Outputs    map[string]interface{} `yaml:"outputs"`
-	State      map[string]interface{} `yaml:"state"`
+	Conditions serialize.YAMLTree      `yaml:"conditions"`
+	Env        SampleConfigEnvironment `yaml:"env"`
+	Spec       SampleConfigSpec        `yaml:"spec"`
+	Outputs    map[string]interface{}  `yaml:"outputs"`
+	State      map[string]interface{}  `yaml:"state"`
 }
 
 type SampleConfigRun struct {

--- a/pkg/metadataapi/sample/auth.go
+++ b/pkg/metadataapi/sample/auth.go
@@ -92,6 +92,13 @@ func NewAuthenticator(sc *opt.SampleConfig, key interface{}) *Authenticator {
 
 			conditionManager := memory.NewConditionManager(conditionOpts...)
 
+			var envOpts []memory.EnvironmentManagerOption
+			if sc.Env != nil {
+				envOpts = append(envOpts, memory.EnvironmentManagerWithInitialEnvironment(sc.Env.Interface()))
+			}
+
+			environmentManager := memory.NewEnvironmentManager(envOpts...)
+
 			var specOpts []memory.SpecManagerOption
 			if sc.Spec != nil {
 				specOpts = append(specOpts, memory.SpecManagerWithInitialSpec(sc.Spec.Interface()))
@@ -114,6 +121,7 @@ func NewAuthenticator(sc *opt.SampleConfig, key interface{}) *Authenticator {
 
 			a.mgrs[step.Hash()] = func(mgrs *builder.MetadataBuilder) {
 				mgrs.SetConditions(conditionManager)
+				mgrs.SetEnvironment(environmentManager)
 				mgrs.SetParameters(parameterManager)
 				mgrs.SetSpec(specManager)
 				mgrs.SetState(stateManager)

--- a/pkg/metadataapi/server/api/environment.go
+++ b/pkg/metadataapi/server/api/environment.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/puppetlabs/horsehead/v2/encoding/transfer"
+	utilapi "github.com/puppetlabs/horsehead/v2/httputil/api"
+	"github.com/puppetlabs/relay-core/pkg/expr/evaluate"
+	"github.com/puppetlabs/relay-core/pkg/manager/resolve"
+	"github.com/puppetlabs/relay-core/pkg/metadataapi/errors"
+	"github.com/puppetlabs/relay-core/pkg/metadataapi/server/middleware"
+)
+
+func (s *Server) GetEnvironmentVariable(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	managers := middleware.Managers(r)
+	name, _ := middleware.Var(r, "name")
+
+	environment, err := managers.Environment().Get(ctx)
+	if err != nil {
+		utilapi.WriteError(ctx, w, ModelReadError(err))
+		return
+	}
+
+	value, ok := environment.Value[name]
+	if !ok {
+		utilapi.WriteError(ctx, w, errors.NewModelNotFoundError())
+		return
+	}
+
+	eval := evaluate.NewEvaluator(
+		evaluate.WithParameterTypeResolver(resolve.NewParameterTypeResolver(managers.Parameters())),
+		evaluate.WithOutputTypeResolver(resolve.NewOutputTypeResolver(managers.StepOutputs())),
+		evaluate.WithSecretTypeResolver(resolve.NewSecretTypeResolver(managers.Secrets())),
+	).ScopeTo(value)
+
+	rv, rerr := eval.EvaluateAll(ctx)
+	if rerr != nil {
+		utilapi.WriteError(ctx, w, errors.NewExpressionEvaluationError(rerr.Error()))
+		return
+	}
+
+	utilapi.WriteObjectOK(ctx, w, rv)
+}
+
+func (s *Server) GetEnvironment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	managers := middleware.Managers(r)
+
+	environment, err := managers.Environment().Get(ctx)
+	if err != nil {
+		utilapi.WriteError(ctx, w, ModelReadError(err))
+		return
+	}
+
+	complete := true
+	evs := make(map[string]interface{})
+	for name, value := range environment.Value {
+		eval := evaluate.NewEvaluator(
+			evaluate.WithParameterTypeResolver(resolve.NewParameterTypeResolver(managers.Parameters())),
+			evaluate.WithOutputTypeResolver(resolve.NewOutputTypeResolver(managers.StepOutputs())),
+			evaluate.WithSecretTypeResolver(resolve.NewSecretTypeResolver(managers.Secrets())),
+		).ScopeTo(value)
+
+		rv, rerr := eval.EvaluateAll(ctx)
+		if rerr != nil {
+			utilapi.WriteError(ctx, w, errors.NewExpressionEvaluationError(rerr.Error()))
+			return
+		}
+
+		if !rv.Complete() {
+			complete = false
+		}
+
+		evs[name] = rv.Value
+	}
+
+	env := &evaluate.JSONResultEnvelope{
+		Value:    transfer.JSONInterface{Data: evs},
+		Complete: complete,
+	}
+
+	utilapi.WriteObjectOK(ctx, w, env)
+}

--- a/pkg/metadataapi/server/api/environment_test.go
+++ b/pkg/metadataapi/server/api/environment_test.go
@@ -1,0 +1,119 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/puppetlabs/relay-core/pkg/expr/evaluate"
+	"github.com/puppetlabs/relay-core/pkg/expr/serialize"
+	sdktestutil "github.com/puppetlabs/relay-core/pkg/expr/testutil"
+	"github.com/puppetlabs/relay-core/pkg/metadataapi/opt"
+	"github.com/puppetlabs/relay-core/pkg/metadataapi/sample"
+	"github.com/puppetlabs/relay-core/pkg/metadataapi/server/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEnvironment(t *testing.T) {
+	ctx := context.Background()
+
+	tokenGenerator, err := sample.NewHS256TokenGenerator(nil)
+	require.NoError(t, err)
+
+	sc := &opt.SampleConfig{
+		Secrets: map[string]string{
+			"test-secret-key": "test-secret-value",
+		},
+		Runs: map[string]*opt.SampleConfigRun{
+			"test": &opt.SampleConfigRun{
+				Steps: map[string]*opt.SampleConfigStep{
+					"previous-task": &opt.SampleConfigStep{
+						Outputs: map[string]interface{}{
+							"test-output-key": "test-output-value",
+						},
+					},
+					"current-task": &opt.SampleConfigStep{
+						Spec: opt.SampleConfigSpec{
+							"superSecret": serialize.YAMLTree{
+								Tree: sdktestutil.JSONSecret("test-secret-key"),
+							},
+							"superOutput": serialize.YAMLTree{
+								Tree: sdktestutil.JSONOutput("previous-task", "test-output-key"),
+							},
+						},
+						Env: opt.SampleConfigEnvironment{
+							"test-environment-variable-from-secret": serialize.YAMLTree{
+								Tree: sdktestutil.JSONSecret("test-secret-key"),
+							},
+							"test-environment-variable-from-output": serialize.YAMLTree{
+								Tree: sdktestutil.JSONOutput("previous-task", "test-output-key"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tokenMap := tokenGenerator.GenerateAll(ctx, sc)
+
+	currentTaskToken, found := tokenMap.ForStep("test", "current-task")
+	require.True(t, found)
+
+	h := api.NewHandler(sample.NewAuthenticator(sc, tokenGenerator.Key()))
+
+	req, err := http.NewRequest(http.MethodGet, "/spec", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+currentTaskToken)
+
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
+
+	var r evaluate.JSONResultEnvelope
+	require.NoError(t, json.NewDecoder(resp.Result().Body).Decode(&r))
+	require.Equal(t, map[string]interface{}{
+		"superSecret": "test-secret-value",
+		"superOutput": "test-output-value",
+	}, r.Value.Data)
+	require.True(t, r.Complete)
+
+	req, err = http.NewRequest(http.MethodGet, "/environment", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+currentTaskToken)
+
+	resp = httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
+
+	require.NoError(t, json.NewDecoder(resp.Result().Body).Decode(&r))
+	require.Equal(t, map[string]interface{}{
+		"test-environment-variable-from-secret": "test-secret-value",
+		"test-environment-variable-from-output": "test-output-value",
+	}, r.Value.Data)
+	require.True(t, r.Complete)
+
+	req, err = http.NewRequest(http.MethodGet, "/environment/test-environment-variable-from-secret", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+currentTaskToken)
+
+	resp = httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
+
+	require.NoError(t, json.NewDecoder(resp.Result().Body).Decode(&r))
+	require.Equal(t, "test-secret-value", r.Value.Data)
+
+	req, err = http.NewRequest(http.MethodGet, "/environment/test-environment-variable-from-output", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+currentTaskToken)
+
+	resp = httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
+
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&r))
+	require.Equal(t, "test-output-value", r.Value.Data)
+}

--- a/pkg/metadataapi/server/api/server.go
+++ b/pkg/metadataapi/server/api/server.go
@@ -21,6 +21,10 @@ func (s *Server) Route(r *mux.Router) {
 	// Events
 	r.HandleFunc("/events", s.PostEvent).Methods(http.MethodPost)
 
+	// Environment
+	r.HandleFunc("/environment", s.GetEnvironment).Methods(http.MethodGet)
+	r.HandleFunc("/environment/{name}", s.GetEnvironmentVariable).Methods(http.MethodGet)
+
 	// Outputs
 	r.HandleFunc("/outputs/{name}", s.PutOutput).Methods(http.MethodPut)
 	r.HandleFunc("/outputs/{stepName}/{name}", s.GetOutput).Methods(http.MethodGet)

--- a/pkg/metadataapi/server/middleware/auth.go
+++ b/pkg/metadataapi/server/middleware/auth.go
@@ -151,6 +151,7 @@ func (ka *KubernetesAuthenticator) injector(mgrs *builder.MetadataBuilder, tags 
 		}
 
 		mgrs.SetConditions(configmap.NewConditionManager(action, immutableMap))
+		mgrs.SetEnvironment(configmap.NewEnvironmentManager(action, immutableMap))
 		mgrs.SetSpec(configmap.NewSpecManager(action, immutableMap))
 		mgrs.SetState(configmap.NewStateManager(action, mutableMap))
 

--- a/pkg/model/environment.go
+++ b/pkg/model/environment.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"context"
+
+	"github.com/puppetlabs/relay-core/pkg/expr/parse"
+)
+
+type Environment struct {
+	Value map[string]parse.Tree
+}
+
+type EnvironmentGetterManager interface {
+	// Get retrieves the environment for this action, if any.
+	Get(ctx context.Context) (*Environment, error)
+}
+
+type EnvironmentSetterManager interface {
+	// Set stores the environment for this action.
+	Set(ctx context.Context, value map[string]interface{}) (*Environment, error)
+}
+
+type EnvironmentManager interface {
+	EnvironmentGetterManager
+	EnvironmentSetterManager
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -26,6 +26,7 @@ type MetadataManagers interface {
 	Conditions() ConditionGetterManager
 	Connections() ConnectionManager
 	Events() EventManager
+	Environment() EnvironmentGetterManager
 	Parameters() ParameterGetterManager
 	Secrets() SecretManager
 	Spec() SpecGetterManager
@@ -38,6 +39,7 @@ type MetadataManagers interface {
 type RunReconcilerManagers interface {
 	Conditions() ConditionSetterManager
 	Parameters() ParameterSetterManager
+	Environment() EnvironmentSetterManager
 	Spec() SpecSetterManager
 	State() StateSetterManager
 }
@@ -45,5 +47,6 @@ type RunReconcilerManagers interface {
 // WebhookTriggerReconcilerManagers are the managers used by the workflow
 // trigger reconciler when configuring a Knative service for the trigger.
 type WebhookTriggerReconcilerManagers interface {
+	Environment() EnvironmentSetterManager
 	Spec() SpecSetterManager
 }

--- a/pkg/obj/configmap.go
+++ b/pkg/obj/configmap.go
@@ -120,6 +120,22 @@ func ConfigureImmutableConfigMapForWorkflowRun(ctx context.Context, cm *ConfigMa
 			}
 		}
 
+		if env := step.Env.Value(); env != nil {
+			em := configmap.NewEnvironmentManager(ModelStep(wr, step), lcm)
+
+			vars := make(map[string]interface{})
+			for name, value := range env {
+				r, err := ev.EvaluateAll(ctx, value)
+				if err != nil {
+					return errmark.MarkUser(err)
+				}
+
+				vars[name] = r.Value.(map[string]interface{})
+			}
+
+			em.Set(ctx, vars)
+		}
+
 		if when := step.When.Value(); when != nil {
 			r, err := ev.EvaluateAll(ctx, when)
 			if err != nil {


### PR DESCRIPTION
Introduces basic Metadata API endpoints and processing for handling environment variables. The processing is similar to specification handling, with a few deviations.

Initially supports the use of parameters, secrets, and outputs. Of particular note is that this cannot resolve connection-related data due to the current implementation of connections. Any necessary rework/refactor of connections will happen at an unspecified point in the future.

Further use of this support (i.e. automatically setting environment variables based on this data) will be added incrementally and independently.