### PR TITLE
Handle workflow runs without steps

### DIFF
--- a/pkg/obj/workflowrun.go
+++ b/pkg/obj/workflowrun.go
@@ -2,6 +2,7 @@ package obj
 
 import (
 	"context"
+	"time"
 
 	"github.com/puppetlabs/horsehead/v2/datastructure"
 	"github.com/puppetlabs/horsehead/v2/graph"
@@ -69,6 +70,20 @@ func (wr *WorkflowRun) IsCancelled() bool {
 	}
 
 	return state.Value() == true
+}
+
+func (wr *WorkflowRun) Complete(ctx context.Context, cl client.Client) error {
+	if wr.Object.Status.StartTime == nil {
+		wr.Object.Status.StartTime = &metav1.Time{Time: time.Now()}
+	}
+
+	if wr.Object.Status.CompletionTime == nil {
+		wr.Object.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	}
+
+	wr.Object.Status.Status = string(WorkflowRunStatusSuccess)
+
+	return wr.PersistStatus(ctx, cl)
 }
 
 func NewWorkflowRun(key client.ObjectKey) *WorkflowRun {

--- a/pkg/reconciler/workflow/reconciler.go
+++ b/pkg/reconciler/workflow/reconciler.go
@@ -70,6 +70,14 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error)
 		return ctrl.Result{}, nil
 	}
 
+	if len(wr.Object.Spec.Workflow.Steps) == 0 {
+		if err := wr.Complete(ctx, r.Client); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	}
+
 	var pr *obj.PipelineRun
 	err = r.metrics.trackDurationWithOutcome(metricWorkflowRunStartUpDuration, func() error {
 		// Configure and save all the infrastructure bits needed to create a


### PR DESCRIPTION
Automatically complete a workflow run without steps, avoiding the unnecessary creation of any associated Tekton artifacts.