### PR TITLE
Hostpath provisioner for testing environment

### DIFF
--- a/pkg/util/testutil/ambassador.go
+++ b/pkg/util/testutil/ambassador.go
@@ -58,7 +58,7 @@ func doInstallAmbassador(ctx context.Context, cl client.Client, mapper meta.REST
 		deployment.Spec.Strategy.RollingUpdate = nil
 	})
 
-	if err := doInstall(ctx, cl, ns.GetName(), "ambassador", patchers...); err != nil {
+	if err := doInstallAndWait(ctx, cl, ns.GetName(), "ambassador", patchers...); err != nil {
 		return err
 	}
 

--- a/pkg/util/testutil/endtoend.go
+++ b/pkg/util/testutil/endtoend.go
@@ -104,8 +104,17 @@ func EndToEndEnvironmentWithAmbassador(ctx context.Context, e *EndToEndEnvironme
 	return doInstallAmbassador(ctx, e.ControllerRuntimeClient, e.RESTMapper)
 }
 
+func EndToEndEnvironmentWithHostpathProvisioner(ctx context.Context, e *EndToEndEnvironment) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	return doInstallHostpathProvisioner(ctx, e.ControllerRuntimeClient)
+}
+
 var _ EndToEndEnvironmentOption = EndToEndEnvironmentWithTekton
 var _ EndToEndEnvironmentOption = EndToEndEnvironmentWithKnative
+var _ EndToEndEnvironmentOption = EndToEndEnvironmentWithAmbassador
+var _ EndToEndEnvironmentOption = EndToEndEnvironmentWithHostpathProvisioner
 
 func doEndToEndEnvironment(fn func(e *EndToEndEnvironment), opts ...EndToEndEnvironmentOption) (bool, error) {
 	// We'll allow 30 minutes to attach the environment and run the test. This

--- a/pkg/util/testutil/fixtures/hostpath/1-hostpath-storage-class.yaml
+++ b/pkg/util/testutil/fixtures/hostpath/1-hostpath-storage-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: example-hostpath
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: example.com/hostpath

--- a/pkg/util/testutil/fixtures/hostpath/2-hostpath-provisioner-rbac.yaml
+++ b/pkg/util/testutil/fixtures/hostpath/2-hostpath-provisioner-rbac.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hostpath-provisioner
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hostpath-provisioner
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hostpath-provisioner
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: hostpath-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: hostpath-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-hostpath-provisioner
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["list", "watch", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-hostpath-provisioner
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: hostpath-provisioner
+    namespace: default
+roleRef:
+  kind: Role
+  name: leader-locking-hostpath-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/util/testutil/fixtures/hostpath/3-hostpath-provisioner.yaml
+++ b/pkg/util/testutil/fixtures/hostpath/3-hostpath-provisioner.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpath-provisioner
+  namespace: default
+spec:
+  containers:
+    - name: hostpath-provisioner
+      image: gcr.io/nebula-tasks/hostpath-provisioner:latest
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      volumeMounts:
+        - name: pv-volume
+          mountPath: /tmp/hostpath-provisioner
+  serviceAccountName: hostpath-provisioner
+  volumes:
+    - name: pv-volume
+      hostPath:
+        path: /tmp/hostpath-provisioner

--- a/pkg/util/testutil/hostpath.go
+++ b/pkg/util/testutil/hostpath.go
@@ -1,0 +1,19 @@
+// https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner
+
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func doInstallHostpathProvisioner(ctx context.Context, cl client.Client) error {
+	return doInstall(ctx, cl, "hostpath-provisioner", "hostpath")
+}
+
+func InstallHostpathProvisioner(t *testing.T, ctx context.Context, cl client.Client) {
+	require.NoError(t, doInstallHostpathProvisioner(ctx, cl))
+}

--- a/pkg/util/testutil/hostpath_test.go
+++ b/pkg/util/testutil/hostpath_test.go
@@ -1,0 +1,22 @@
+package testutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/puppetlabs/relay-core/pkg/util/testutil"
+)
+
+func TestInstallHostpathProvisioner(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	testutil.WithEndToEndEnvironment(t, func(e2e *testutil.EndToEndEnvironment) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		testutil.InstallHostpathProvisioner(t, ctx, e2e.ControllerRuntimeClient)
+	})
+}

--- a/pkg/util/testutil/install.go
+++ b/pkg/util/testutil/install.go
@@ -41,11 +41,20 @@ func doInstall(ctx context.Context, cl client.Client, namespace, name string, pa
 		return err
 	}
 
-	err = WaitForServicesToBeReady(ctx, cl, namespace)
+	log.Printf("installed %s in %s after %s", name, namespace, time.Now().Sub(requested))
+	return nil
+}
+
+func doInstallAndWait(ctx context.Context, cl client.Client, namespace, name string, patchers ...ParseKubernetesManifestPatcherFunc) error {
+	doInstall(ctx, cl, namespace, name, patchers...)
+
+	requested := time.Now()
+
+	err := WaitForServicesToBeReady(ctx, cl, namespace)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("installed %s in %s after %s", name, namespace, time.Now().Sub(requested))
+	log.Printf("waited for services to be ready for %s in %s after %s", name, namespace, time.Now().Sub(requested))
 	return nil
 }

--- a/pkg/util/testutil/knative.go
+++ b/pkg/util/testutil/knative.go
@@ -9,7 +9,7 @@ import (
 )
 
 func doInstallKnativeServing(ctx context.Context, cl client.Client) error {
-	return doInstall(ctx, cl, "knative-serving", "knative")
+	return doInstallAndWait(ctx, cl, "knative-serving", "knative")
 }
 
 func InstallKnativeServing(t *testing.T, ctx context.Context, cl client.Client) {

--- a/pkg/util/testutil/tekton.go
+++ b/pkg/util/testutil/tekton.go
@@ -9,7 +9,7 @@ import (
 )
 
 func doInstallTektonPipeline(ctx context.Context, cl client.Client) error {
-	return doInstall(ctx, cl, "tekton-pipelines", "tekton")
+	return doInstallAndWait(ctx, cl, "tekton-pipelines", "tekton")
 }
 
 func InstallTektonPipeline(t *testing.T, ctx context.Context, cl client.Client) {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -33,6 +33,7 @@ func TestMain(m *testing.M) {
 		func(e *testutil.EndToEndEnvironment) {
 			e2e = e
 		},
+		testutil.EndToEndEnvironmentWithHostpathProvisioner,
 		testutil.EndToEndEnvironmentWithTekton,
 		testutil.EndToEndEnvironmentWithKnative,
 		testutil.EndToEndEnvironmentWithAmbassador,


### PR DESCRIPTION
Adding a slightly more comprehensive hostpath provisioner based on https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner.

`gcr.io/nebula-tasks/hostpath-provisioner:latest` is built straight from this example for now.

May or may not change in the future.
Intended for immediate testing.

