### PR TITLE
Initial tool injection handling

### DIFF
--- a/cmd/relay-operator/main.go
+++ b/cmd/relay-operator/main.go
@@ -56,6 +56,7 @@ func main() {
 	tenantSandboxing := fs.Bool("tenant-sandboxing", false, "enables gVisor sandbox for tenant pods")
 	sentryDSN := fs.String("sentry-dsn", "", "the Sentry DSN to use for error reporting")
 	dynamicRBACBinding := fs.Bool("dynamic-rbac-binding", false, "enable if RBAC rules are set up dynamically for the operator to reduce unhelpful reported errors")
+	toolInjectionImage := fs.String("tool-injection-image", "relaysh/relay-runtime-tools", "image to use for the tool injection suite")
 
 	fs.Parse(os.Args[1:])
 
@@ -161,6 +162,7 @@ func main() {
 		WebhookServerKeyDir:     *webhookServerKeyDir,
 		AlertsDelegate:          alertsDelegate,
 		DynamicRBACBinding:      *dynamicRBACBinding,
+		ToolInjectionImage:      *toolInjectionImage,
 	}
 
 	dm, err := dependency.NewDependencyManager(cfg, kcc, vc, jwtSigner, blobStore, mets)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type WorkflowControllerConfig struct {
 	WebhookServerPort       int
 	WebhookServerKeyDir     string
 	DynamicRBACBinding      bool
+	ToolInjectionImage      string
 	AlertsDelegate          alerts.DelegateFunc
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1,12 +1,16 @@
 package model
 
 const (
-	DefaultImage = "alpine:latest"
+	DefaultImage              = "alpine:latest"
+	DefaultToolInjectionImage = "relaysh/relay-runtime-tools"
 
 	// TODO All tool injection settings should be fully configurable
 	ToolInjectionImagePath = "/relay/runtime/tools/."
 	ToolInjectionMountName = "relay-runtime-tools"
 	ToolInjectionMountPath = "/var/lib/puppet/relay/"
+
+	ToolInjectionVolumeClaimSuffixReadOnlyMany  = "-volume-rox"
+	ToolInjectionVolumeClaimSuffixReadWriteOnce = "-volume-rwo"
 )
 
 const (

--- a/pkg/obj/knativeservice.go
+++ b/pkg/obj/knativeservice.go
@@ -182,6 +182,10 @@ func ConfigureKnativeService(ctx context.Context, s *KnativeService, wtd *Webhoo
 		return err
 	}
 
+	if wtd.Tenant.Object.Spec.ToolInjection.VolumeClaimTemplate != nil {
+		Annotate(&template.ObjectMeta, model.RelayControllerToolsVolumeClaimAnnotation, wtd.Tenant.Object.GetName()+model.ToolInjectionVolumeClaimSuffixReadOnlyMany)
+	}
+
 	s.Object.Spec = servingv1.ServiceSpec{
 		ConfigurationSpec: servingv1.ConfigurationSpec{
 			Template: template,

--- a/pkg/obj/task.go
+++ b/pkg/obj/task.go
@@ -80,6 +80,13 @@ func ConfigureTask(ctx context.Context, t *Task, wrd *WorkflowRunDeps, ws *nebul
 		return err
 	}
 
+	// TODO Reference the tool injection from the tenant (once this is available)
+	// For now, we'll assume an explicit tenant reference implies the use of the tool injection suite
+	if wrd.WorkflowRun.Object.Spec.TenantRef != nil {
+		claim := wrd.WorkflowRun.Object.Spec.TenantRef.Name + model.ToolInjectionVolumeClaimSuffixReadOnlyMany
+		Annotate(&t.Object.ObjectMeta, model.RelayControllerToolsVolumeClaimAnnotation, claim)
+	}
+
 	t.Object.Spec.Steps = []tektonv1beta1.Step{step}
 
 	return nil

--- a/pkg/obj/tenantdeps.go
+++ b/pkg/obj/tenantdeps.go
@@ -5,6 +5,7 @@ import (
 
 	relayv1beta1 "github.com/puppetlabs/relay-core/pkg/apis/relay.sh/v1beta1"
 	"github.com/puppetlabs/relay-core/pkg/model"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,6 +49,18 @@ func NewAPITriggerEventSink(namespace string, sink *relayv1beta1.APITriggerEvent
 	return tes
 }
 
+type ToolInjection struct {
+	VolumeClaimTemplate *corev1.PersistentVolumeClaim
+}
+
+func NewToolInjection(namespace string, toolInjection relayv1beta1.ToolInjection) *ToolInjection {
+	ti := &ToolInjection{
+		VolumeClaimTemplate: toolInjection.VolumeClaimTemplate,
+	}
+
+	return ti
+}
+
 type TenantDeps struct {
 	Tenant *Tenant
 
@@ -60,6 +73,7 @@ type TenantDeps struct {
 	LimitRange    *LimitRange
 
 	APITriggerEventSink *APITriggerEventSink
+	ToolInjection       *ToolInjection
 }
 
 var _ Persister = &TenantDeps{}
@@ -159,6 +173,8 @@ func NewTenantDeps(t *Tenant) *TenantDeps {
 	if sink := t.Object.Spec.TriggerEventSink.API; sink != nil {
 		td.APITriggerEventSink = NewAPITriggerEventSink(td.Tenant.Key.Namespace, sink)
 	}
+
+	td.ToolInjection = NewToolInjection(td.Tenant.Key.Namespace, td.Tenant.Object.Spec.ToolInjection)
 
 	return td
 }

--- a/pkg/reconciler/tenant/reconciler.go
+++ b/pkg/reconciler/tenant/reconciler.go
@@ -3,11 +3,15 @@ package tenant
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/puppetlabs/relay-core/pkg/config"
 	"github.com/puppetlabs/relay-core/pkg/errmark"
+	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/puppetlabs/relay-core/pkg/obj"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,14 +69,186 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error)
 
 	tdr := obj.AsTenantDepsResult(deps, deps.Persist(ctx, r.Client))
 
-	obj.ConfigureTenant(tn, tdr)
+	obj.ConfigureTenant(tn, tdr, []batchv1.JobCondition{})
 
 	if err := tn.PersistStatus(ctx, r.Client); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if !tn.Ready() {
-		return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+	if tn.Object.Spec.ToolInjection.VolumeClaimTemplate == nil {
+		return ctrl.Result{}, nil
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deps.Tenant.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadWriteOnce,
+			Namespace: tn.Object.Spec.NamespaceTemplate.Metadata.GetName(),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources:        tn.Object.Spec.ToolInjection.VolumeClaimTemplate.Spec.Resources,
+			StorageClassName: tn.Object.Spec.ToolInjection.VolumeClaimTemplate.Spec.StorageClassName,
+		},
+	}
+
+	key := client.ObjectKey{Name: deps.Tenant.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadWriteOnce, Namespace: deps.Tenant.Object.Spec.NamespaceTemplate.Metadata.GetName()}
+	pvco, err := obj.ApplyPersistentVolumeClaim(ctx, r.Client, key, pvc)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if pvco.Object.Spec.VolumeName == "" || pvco.Object.Status.Phase != corev1.ClaimBound {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	pv := &corev1.PersistentVolume{}
+
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: pvco.Object.Spec.VolumeName}, pv); k8serrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	if pv.Spec.GCEPersistentDisk == nil && pv.Spec.HostPath == nil {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	pvn := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tn.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+			Capacity:         pv.Spec.Capacity,
+			StorageClassName: pv.Spec.StorageClassName,
+		},
+	}
+
+	pvn.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
+
+	if pv.Spec.GCEPersistentDisk != nil {
+		pvn.Spec.PersistentVolumeSource = corev1.PersistentVolumeSource{
+			GCEPersistentDisk: pv.Spec.GCEPersistentDisk,
+		}
+	} else if pv.Spec.HostPath != nil {
+		pvn.Spec.PersistentVolumeSource = corev1.PersistentVolumeSource{
+			HostPath: pv.Spec.HostPath,
+		}
+	}
+
+	key = client.ObjectKey{Name: tn.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany}
+	_, err = obj.ApplyPersistentVolume(ctx, r.Client, key, pvn)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	pvcn := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvn.GetName(),
+			Namespace: tn.Object.Spec.NamespaceTemplate.Metadata.GetName(),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+			Resources:        pvco.Object.Spec.Resources,
+			StorageClassName: pvco.Object.Spec.StorageClassName,
+		},
+	}
+
+	key = client.ObjectKey{Name: tn.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany, Namespace: tn.Object.Spec.NamespaceTemplate.Metadata.GetName()}
+	_, err = obj.ApplyPersistentVolumeClaim(ctx, r.Client, key, pvcn)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: pvcn.GetNamespace(), Name: pvcn.GetName()}, pvcn); k8serrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	if pvcn.Spec.VolumeName == "" {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	tii := model.DefaultToolInjectionImage
+	if r.Config.ToolInjectionImage != "" {
+		tii = r.Config.ToolInjectionImage
+	}
+
+	container := corev1.Container{
+		Name:    model.ToolInjectionMountName,
+		Image:   tii,
+		Command: []string{"cp"},
+		Args:    []string{"-r", model.ToolInjectionImagePath, model.ToolInjectionMountPath},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      model.ToolInjectionMountName,
+				MountPath: model.ToolInjectionMountPath,
+			},
+		},
+	}
+
+	defaultLimit := int32(1)
+
+	j := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tn.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany,
+			Namespace: tn.Object.Spec.NamespaceTemplate.Metadata.GetName(),
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      model.ToolInjectionMountName,
+					Namespace: tn.Object.Spec.NamespaceTemplate.Metadata.GetName(),
+				},
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{container},
+					RestartPolicy: corev1.RestartPolicyNever,
+					Volumes: []corev1.Volume{
+						{
+							Name: model.ToolInjectionMountName,
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvco.Object.GetName(),
+								},
+							},
+						},
+					},
+				},
+			},
+			BackoffLimit: &defaultLimit,
+			Completions:  &defaultLimit,
+			Parallelism:  &defaultLimit,
+		},
+	}
+
+	key = client.ObjectKey{Name: tn.Object.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany, Namespace: tn.Object.Spec.NamespaceTemplate.Metadata.GetName()}
+	job, err := obj.ApplyJob(ctx, r.Client, key, j)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return ctrl.Result{}, err
+	}
+
+	complete := false
+	failed := false
+	for _, cond := range job.Object.Status.Conditions {
+		switch cond.Type {
+		case batchv1.JobComplete:
+			switch cond.Status {
+			case corev1.ConditionTrue:
+				complete = true
+			}
+		case batchv1.JobFailed:
+			switch cond.Status {
+			case corev1.ConditionTrue:
+				failed = true
+			}
+		}
+	}
+
+	if !complete && !failed {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	obj.ConfigureTenant(tn, tdr, job.Object.Status.Conditions)
+
+	if err := tn.PersistStatus(ctx, r.Client); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/reconciler/tenant/reconciler.go
+++ b/pkg/reconciler/tenant/reconciler.go
@@ -76,6 +76,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error)
 	}
 
 	if tn.Object.Spec.ToolInjection.VolumeClaimTemplate == nil {
+		if !tn.Ready() {
+			return ctrl.Result{Requeue: true}, nil
+		}
+
 		return ctrl.Result{}, nil
 	}
 
@@ -249,6 +253,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error)
 
 	if err := tn.PersistStatus(ctx, r.Client); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if !tn.Ready() {
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/tests/e2e/tenant_test.go
+++ b/tests/e2e/tenant_test.go
@@ -6,13 +6,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	relayv1beta1 "github.com/puppetlabs/relay-core/pkg/apis/relay.sh/v1beta1"
+	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/puppetlabs/relay-core/pkg/obj"
 	"github.com/puppetlabs/relay-core/pkg/util/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -272,5 +276,65 @@ func TestTenantNamespaceUpdate(t *testing.T) {
 		} else {
 			require.NotEmpty(t, ns1.GetDeletionTimestamp())
 		}
+	})
+}
+
+func TestTenantToolInjection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	WithConfig(t, ctx, []ConfigOption{
+		ConfigWithTenantReconciler,
+	}, func(cfg *Config) {
+		child := fmt.Sprintf("%s-child-1", cfg.Namespace.GetName())
+
+		size, _ := resource.ParseQuantity("50Mi")
+		storageClassName := "relay-hostpath"
+		tenant := &relayv1beta1.Tenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cfg.Namespace.GetName(),
+				Name:      "tenant-" + uuid.New().String(),
+			},
+			Spec: relayv1beta1.TenantSpec{
+				NamespaceTemplate: relayv1beta1.NamespaceTemplate{
+					Metadata: metav1.ObjectMeta{
+						Name: child,
+					},
+				},
+				ToolInjection: relayv1beta1.ToolInjection{
+					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+						Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceStorage: size,
+								},
+							},
+							StorageClassName: &storageClassName,
+						},
+					},
+				},
+			},
+		}
+
+		CreateAndWaitForTenant(t, ctx, tenant)
+
+		var ns corev1.Namespace
+		require.Equal(t, child, tenant.Status.Namespace)
+		require.NoError(t, e2e.ControllerRuntimeClient.Get(ctx, client.ObjectKey{Name: child}, &ns))
+
+		var job batchv1.Job
+		require.NoError(t, e2e.ControllerRuntimeClient.Get(ctx, client.ObjectKey{Name: tenant.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany, Namespace: tenant.Status.Namespace}, &job))
+		e2e.ControllerRuntimeClient.Delete(ctx, &job)
+
+		var pvc corev1.PersistentVolumeClaim
+		require.NoError(t, e2e.ControllerRuntimeClient.Get(ctx, client.ObjectKey{Name: tenant.GetName() + model.ToolInjectionVolumeClaimSuffixReadWriteOnce, Namespace: tenant.Status.Namespace}, &pvc))
+		e2e.ControllerRuntimeClient.Delete(ctx, &pvc)
+
+		require.NoError(t, e2e.ControllerRuntimeClient.Get(ctx, client.ObjectKey{Name: tenant.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany, Namespace: tenant.Status.Namespace}, &pvc))
+		e2e.ControllerRuntimeClient.Delete(ctx, &pvc)
+
+		var pv corev1.PersistentVolume
+		require.NoError(t, e2e.ControllerRuntimeClient.Get(ctx, client.ObjectKey{Name: tenant.GetName() + model.ToolInjectionVolumeClaimSuffixReadOnlyMany}, &pv))
+		e2e.ControllerRuntimeClient.Delete(ctx, &pv)
 	})
 }


### PR DESCRIPTION
Adds initial handling of tool injection. Currently expands the tenant reconciler directly to layer on support in a limited fashion. In the future, this may be collapsed into the tenant dependencies in a cleaner manner.
- Tool injection status is being derived from the job status directly; this needs smoothed over.
- Workflow runs cannot load the tenant reference currently; this is being temporarily worked around.
- Does not handle updates to the tool injection image.
- Does not cleanup the original PVC used for the initial write access.
- Does not cleanup any jobs related to creation of the PVCs.
- Only supports GCE and Hostpath currently (and is essentially hardcoded).