### PR TITLE
fixes the error type comparison when validating schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,6 @@ require (
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4 // indirect
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.1
-	github.com/onsi/ginkgo v1.12.1
-	github.com/onsi/gomega v1.10.1
 	github.com/opencontainers/runc v1.0.0-rc6 // indirect
 	github.com/prometheus/client_golang v1.6.0 // indirect
 	github.com/puppetlabs/errawr-gen v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1455,7 +1455,6 @@ github.com/puppetlabs/errawr-go/v2 v2.1.0 h1:SMZe3K6fSWOpo8Ol1u1G3slNroihmuka5uu
 github.com/puppetlabs/errawr-go/v2 v2.1.0/go.mod h1:TFKBrNpfPDG8ta8/NfaqpC+hMMsJqd9xKvBJDRgHFCQ=
 github.com/puppetlabs/errawr-go/v2 v2.2.0 h1:HiX2K0PoZCwe2F2ZPf4QF3xeNzNNuov3QCwZprsNcqI=
 github.com/puppetlabs/errawr-go/v2 v2.2.0/go.mod h1:SJ1lTqOW0HcfqVPS/F7kSrUAc4o/6DfjBatQ5TTS/JU=
-github.com/puppetlabs/horsehead v1.11.0 h1:1eUpsDPyaFBTQQr61D2H0zuKOG9oPaurSrmLRtr/iTs=
 github.com/puppetlabs/horsehead/v2 v2.16.0 h1:K3u6ct/omcVCcUxoam3jpZI8uRo5vpABGM0Qvxv3dkc=
 github.com/puppetlabs/horsehead/v2 v2.16.0/go.mod h1:ixb6zHYDDe9tvWRi2YhJpljRfQukggDZ6KGfZkezvEc=
 github.com/puppetlabs/paesslerag-gval v1.0.2-0.20191119012647-d2c694821b5b h1:L3KBXqsUZK0OsVAN6DQ99OzI18BvtP+uVtX0oTjCxhQ=
@@ -2243,8 +2242,6 @@ google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1 h1:SfXqXS5hkufcdZ/mHtYCh53P2b+92WQq/DZcKLgsFRs=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
-google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -2414,7 +2411,6 @@ knative.dev/pkg v0.0.0-20200702222342-ea4d6e985ba0 h1:+k2ADqygEgy5BIEahUUEgdY3Lb
 knative.dev/pkg v0.0.0-20200702222342-ea4d6e985ba0/go.mod h1:7T15JzvjKXWnvIKcohz4brrsVq8jvwAcJwWY9xigAc0=
 knative.dev/serving v0.16.0 h1:vtYJRsCHSl1PkyXDoDTJ0ksJIlAEEbxyBHqURbbgC5g=
 knative.dev/serving v0.16.0/go.mod h1:XG6NOSbtstohsGGl0UYcTazPDMLWDk8W8F0Cd+W9ioI=
-knative.dev/serving v0.19.0 h1:aXJs15J7FKocVFxB+PTS2Yned2+8fvrgxMQH2sV/DWM=
 knative.dev/test-infra v0.0.0-20200630141629-15f40fe97047/go.mod h1:30tMsI1VXrG2m4ut7CFZbLg1VbcRsslPfGU+GWILm6E=
 layeh.com/radius v0.0.0-20190322222518-890bc1058917 h1:BDXFaFzUt5EIqe/4wrTc4AcYZWP6iC6Ult+jQWLh5eU=
 layeh.com/radius v0.0.0-20190322222518-890bc1058917/go.mod h1:fywZKyu//X7iRzaxLgPWsvc0L26IUpVvE/aeIL2JtIQ=

--- a/pkg/metadataapi/server/api/validate.go
+++ b/pkg/metadataapi/server/api/validate.go
@@ -71,8 +71,8 @@ func (s *Server) PostValidate(w http.ResponseWriter, r *http.Request) {
 
 				schema, err := s.schemaRegistry.GetByImage(ref)
 				if err != nil {
-					captureErr = err
-					if !goerrors.Is(err, &validation.SchemaDoesNotExistError{}) {
+					var noTrackCause *validation.SchemaDoesNotExistError
+					if !goerrors.As(err, &noTrackCause) {
 						captureErr = errors.NewValidationSchemaLookupError().WithCause(err)
 					}
 				} else {

--- a/pkg/metadataapi/server/api/validate_test.go
+++ b/pkg/metadataapi/server/api/validate_test.go
@@ -34,7 +34,7 @@ func TestValidationCapture(t *testing.T) {
 		validationReport *alertstest.ReporterRecorder
 	}{
 		{
-			description: "missing spec schema",
+			description: "missing spec schema should not send a report",
 			sc: &opt.SampleConfig{
 				Connections: map[memory.ConnectionKey]map[string]interface{}{
 					memory.ConnectionKey{Type: "aws", Name: "test-aws-connection"}: {
@@ -72,18 +72,9 @@ func TestValidationCapture(t *testing.T) {
 					},
 				},
 			},
-			validationReport: &alertstest.ReporterRecorder{
-				Tags: []trackers.Tag{
-					{
-						Key:   "relay.spec.validation-error",
-						Value: "relaysh/image",
-					},
-				},
-				Err: errors.NewValidationSchemaLookupError().WithCause(&validation.SchemaDoesNotExistError{Name: "relaysh/image"}),
-			},
 		},
 		{
-			description: "invalid spec schema",
+			description: "invalid spec schema should send a report",
 			sc: &opt.SampleConfig{
 				Connections: map[memory.ConnectionKey]map[string]interface{}{
 					memory.ConnectionKey{Type: "kubernetes", Name: "test-kubernetes-connection"}: {
@@ -127,7 +118,7 @@ func TestValidationCapture(t *testing.T) {
 			},
 		},
 		{
-			description: "valid spec schema",
+			description: "valid spec schema should not send a report",
 			sc: &opt.SampleConfig{
 				Connections: map[memory.ConnectionKey]map[string]interface{}{
 					memory.ConnectionKey{Type: "kubernetes", Name: "test-kubernetes-connection"}: {
@@ -185,6 +176,7 @@ func TestValidationCapture(t *testing.T) {
 					require.Len(t, capturer.ReporterRecorders, 1)
 					report := capturer.ReporterRecorders[0]
 
+					t.Logf("validation report to be sent: %+v", report.Err)
 					require.Equal(t, c.validationReport, report)
 				} else {
 					require.Len(t, capturer.ReporterRecorders, 0)


### PR DESCRIPTION
This commit changes the error type comparison logic to use errors.As
instead of errors.Is, which fixes the issue where
SchemaDoesNotExistError was being captured and sent to the monitoring
backend.