### PR TITLE
Send timestamp as part of log message

### DIFF
--- a/cmd/relay-runtime-tools/runner.go
+++ b/cmd/relay-runtime-tools/runner.go
@@ -16,7 +16,9 @@ import (
 	"os/exec"
 	"os/signal"
 	"syscall"
+	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/puppetlabs/relay-core/pkg/entrypoint"
 	"github.com/puppetlabs/relay-core/pkg/expr/model"
 	"github.com/puppetlabs/relay-pls/pkg/plspb"
@@ -129,10 +131,16 @@ func scan(mu *url.URL, scanner *bufio.Scanner, out *os.File, log *plspb.LogCreat
 		line := scanner.Text()
 
 		if log != nil {
-			postLogMessage(mu, &plspb.LogMessageAppendRequest{
+			message := &plspb.LogMessageAppendRequest{
 				LogId:   log.GetLogId(),
 				Payload: []byte(line),
-			})
+			}
+
+			if ts, err := ptypes.TimestampProto(time.Now().UTC()); err == nil {
+				message.Timestamp = ts
+			}
+
+			postLogMessage(mu, message)
 		}
 
 		out.WriteString(line)

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/puppetlabs/horsehead/v2 v2.16.0
 	github.com/puppetlabs/paesslerag-gval v1.0.2-0.20191119012647-d2c694821b5b
 	github.com/puppetlabs/paesslerag-jsonpath v0.1.2-0.20201115225516-4a6f3d111e98
-	github.com/puppetlabs/relay-pls v0.0.0-20201031183836-037cec6c0067
+	github.com/puppetlabs/relay-pls v0.0.0-20201125074651-13575df50b51
 	github.com/rancher/remotedialer v0.2.5
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd

--- a/go.sum
+++ b/go.sum
@@ -1463,6 +1463,8 @@ github.com/puppetlabs/paesslerag-jsonpath v0.1.2-0.20201115225516-4a6f3d111e98 h
 github.com/puppetlabs/paesslerag-jsonpath v0.1.2-0.20201115225516-4a6f3d111e98/go.mod h1:fU2lLssuZDiOPlZS0sPObg4WPO1Cg1QSGJD3QTbjH7g=
 github.com/puppetlabs/relay-pls v0.0.0-20201031183836-037cec6c0067 h1:LUW1I4JXOJV0/mlamZoCNfGp8u3VTwxYZbQrnTLZe8g=
 github.com/puppetlabs/relay-pls v0.0.0-20201031183836-037cec6c0067/go.mod h1:xtYyc7gvvVZtfAn5kM89ihJj6v5zdBjNjMfp+a6z+8o=
+github.com/puppetlabs/relay-pls v0.0.0-20201125074651-13575df50b51 h1:NwccjCOhZOi0l4w68vPJOV99ctreO/YlrY+RNiz7Llc=
+github.com/puppetlabs/relay-pls v0.0.0-20201125074651-13575df50b51/go.mod h1:xtYyc7gvvVZtfAn5kM89ihJj6v5zdBjNjMfp+a6z+8o=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=
 github.com/rancher/remotedialer v0.2.5 h1:rNMMcJp5fU7FZ3wGFKSmDrXrSt8MYo5na4CzXddIr2A=


### PR DESCRIPTION
Sends the timestamp as part of log message. Previously this was only being set downstream, which can lead to inaccuracy and drift.