### PR TITLE
Add retry logic for 5xx status codes

### DIFF
--- a/cmd/relay-runtime-tools/main.go
+++ b/cmd/relay-runtime-tools/main.go
@@ -21,11 +21,12 @@ var (
 func main() {
 	flag.Parse()
 
+	// FIXME Implement configurable timeouts
 	e := entrypoint.Entrypointer{
 		Entrypoint: *ep,
 		Args:       flag.Args(),
 		Runner: &entrypoint.RealRunner{
-			TimeoutLong:  5 * time.Minute,
+			TimeoutLong:  1 * time.Minute,
 			TimeoutShort: 5 * time.Second,
 		},
 	}

--- a/go.sum
+++ b/go.sum
@@ -1466,6 +1466,7 @@ github.com/puppetlabs/horsehead v1.11.0 h1:1eUpsDPyaFBTQQr61D2H0zuKOG9oPaurSrmLR
 github.com/puppetlabs/horsehead/v2 v2.16.0 h1:K3u6ct/omcVCcUxoam3jpZI8uRo5vpABGM0Qvxv3dkc=
 github.com/puppetlabs/horsehead/v2 v2.16.0/go.mod h1:ixb6zHYDDe9tvWRi2YhJpljRfQukggDZ6KGfZkezvEc=
 github.com/puppetlabs/leg v0.0.0-20210106185521-ee413eca2bb9 h1:fVqLvlslndN/8AobpCRenxvcz9ZsfepevHFMaHYGAFU=
+github.com/puppetlabs/leg v0.0.0-20210114184330-931828f453b4 h1:A3NEwJkpGLrz7yobAA1Uzb1/rnEet0zgC1ewc+iWrJQ=
 github.com/puppetlabs/leg/mathutil v0.1.0 h1:9O/fsCWA0oEybKLtxKOPGl1lHA2etLbopwkGOf3dG0w=
 github.com/puppetlabs/leg/mathutil v0.1.0/go.mod h1:1Ni3bNk/721eP9PAhkTsx2CoXUEP636UKEx5mIlph3s=
 github.com/puppetlabs/leg/timeutil v0.2.0 h1:f5Dbivofe8zoFu3GxMopNeCI2x0rlKq6dJqZ1t10/b8=

--- a/pkg/entrypoint/runner.go
+++ b/pkg/entrypoint/runner.go
@@ -327,6 +327,16 @@ func getResponse(request *http.Request, timeout time.Duration, waitOptions []ret
 		if rerr != nil {
 			return false, rerr
 		}
+
+		if response != nil {
+			// TODO Consider expanding to all 5xx (and possibly some 4xx) status codes
+			switch response.StatusCode {
+			case http.StatusInternalServerError, http.StatusBadGateway,
+				http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+				return false, nil
+			}
+		}
+
 		return true, nil
 	}, waitOptions...)
 	if err != nil {


### PR DESCRIPTION
- Added handling of some 5xx response status codes for the retry logic. We're seeing a mixture of both outright errors and 500s in our environments currently.
- Unfortunately, due to the number of integration tests that utilize the entrypointer without an actual Metadata API to access, large timeout values break the current tests. This will need a better solution in the future, but for now, this attempts to define reasonable default timeouts that will still be effective in live environments (which will be thoroughly tested for efficacy).