### PR TITLE
Improve function evaluation

### DIFF
--- a/pkg/expr/evaluate/errors.go
+++ b/pkg/expr/evaluate/errors.go
@@ -111,6 +111,10 @@ func (e *PathEvaluationError) UnderlyingCause() error {
 	return err
 }
 
+func (e *PathEvaluationError) Unwrap() error {
+	return e.Cause
+}
+
 func (e *PathEvaluationError) Error() string {
 	path, err := e.trace()
 	return fmt.Sprintf("path %q: %+v", strings.Join(path, "."), err)

--- a/pkg/expr/evaluate/evaluate.go
+++ b/pkg/expr/evaluate/evaluate.go
@@ -357,32 +357,14 @@ func (e *Evaluator) evaluateInvocation(ctx context.Context, im map[string]interf
 		case []interface{}:
 			args := make([]model.Evaluable, len(ra))
 			for i, value := range ra {
-				evaluated, err := e.EvaluateAll(ctx, value)
-				if err != nil {
-					return nil, &InvalidInvocationError{Name: name, Cause: err}
-				}
-
-				if evaluated == nil {
-					return nil, &InvalidInvocationError{Name: name, Cause: fn.ErrPositionalArgsNotAccepted}
-				}
-
-				args[i] = e.ScopeTo(evaluated.Value).Copy(WithLanguage(LanguagePath))
+				args[i] = e.ScopeTo(value).Copy(WithLanguage(LanguagePath))
 			}
 
 			invoker, err = e.invocationResolver.ResolveInvocationPositional(ctx, name, args)
 		case map[string]interface{}:
 			args := make(map[string]model.Evaluable, len(ra))
 			for key, value := range ra {
-				evaluated, err := e.EvaluateAll(ctx, value)
-				if err != nil {
-					return nil, &InvalidInvocationError{Name: name, Cause: err}
-				}
-
-				if evaluated == nil {
-					return nil, &InvalidInvocationError{Name: name, Cause: fn.ErrKeywordArgsNotAccepted}
-				}
-
-				args[key] = e.ScopeTo(evaluated.Value).Copy(WithLanguage(LanguagePath))
+				args[key] = e.ScopeTo(value).Copy(WithLanguage(LanguagePath))
 			}
 
 			invoker, err = e.invocationResolver.ResolveInvocation(ctx, name, args)
@@ -458,7 +440,9 @@ func (e *Evaluator) evaluateUnchecked(ctx context.Context, v interface{}, depth 
 			if strings.HasPrefix(first, "$fn.") {
 				return e.evaluateInvocation(ctx, vt)
 			}
-		} else if depth == 1 {
+		}
+
+		if depth == 1 {
 			return &model.Result{Value: v}, nil
 		}
 

--- a/pkg/expr/evaluate/select.go
+++ b/pkg/expr/evaluate/select.go
@@ -2,6 +2,7 @@ package evaluate
 
 import (
 	"context"
+	"fmt"
 
 	gval "github.com/puppetlabs/paesslerag-gval"
 	jsonpath "github.com/puppetlabs/paesslerag-jsonpath"
@@ -12,12 +13,25 @@ func variableSelector(e *Evaluator, r *model.Result) func(path gval.Evaluables) 
 	visitor := variableVisitor(e, r)
 
 	return func(path gval.Evaluables) gval.Evaluable {
-		return func(ctx context.Context, v interface{}) (interface{}, error) {
+		return func(ctx context.Context, v interface{}) (rv interface{}, err error) {
+			var parents []interface{}
+			defer func() {
+				if err != nil {
+					for i := len(parents) - 1; i >= 0; i-- {
+						err = &PathEvaluationError{
+							Path:  fmt.Sprintf("%v", parents[i]),
+							Cause: err,
+						}
+					}
+				}
+			}()
+
 			for _, key := range path {
 				key, err := key(ctx, v)
 				if err != nil {
 					return nil, err
 				}
+				parents = append(parents, key)
 
 				// For consistency we use the JSONPath visitor here even though
 				// it isn't strictly necessary.
@@ -26,9 +40,7 @@ func variableSelector(e *Evaluator, r *model.Result) func(path gval.Evaluables) 
 					nv = pv.Value
 					return nil
 				})
-				if perr, ok := err.(jsonpath.PropagatableError); ok {
-					return nil, perr
-				} else if err != nil {
+				if err != nil {
 					return nil, err
 				} else if nv == nil {
 					return nil, nil
@@ -45,7 +57,18 @@ func variableSelector(e *Evaluator, r *model.Result) func(path gval.Evaluables) 
 func variableVisitor(e *Evaluator, r *model.Result) jsonpath.VariableVisitor {
 	return jsonpath.VariableVisitorFuncs{
 		VisitChildFunc: func(ctx context.Context, parameter interface{}, key interface{}, next func(ctx context.Context, pv jsonpath.PathValue) error) error {
-			return jsonpath.DefaultVariableVisitor().VisitChild(ctx, parameter, key, func(ctx context.Context, pv jsonpath.PathValue) error {
+			// We need to evaluate the base parameter before indexing in. This
+			// is because the base parameter could be itself a $type, $encoding,
+			// etc.
+			nr, err := e.evaluate(ctx, parameter, 1)
+			if err != nil {
+				return err
+			} else if !nr.Complete() {
+				r.Extends(nr)
+				return nil
+			}
+
+			return jsonpath.DefaultVariableVisitor().VisitChild(ctx, nr.Value, key, func(ctx context.Context, pv jsonpath.PathValue) error {
 				// Expand just this value without recursing.
 				nr, err := e.evaluate(ctx, pv.Value, 1)
 				if err != nil {

--- a/pkg/expr/fnlib/path_test.go
+++ b/pkg/expr/fnlib/path_test.go
@@ -2,6 +2,8 @@ package fnlib_test
 
 import (
 	"context"
+	"math/cmplx"
+	"reflect"
 	"testing"
 
 	jsonpath "github.com/puppetlabs/paesslerag-jsonpath"
@@ -9,24 +11,33 @@ import (
 	"github.com/puppetlabs/relay-core/pkg/expr/fn"
 	"github.com/puppetlabs/relay-core/pkg/expr/fnlib"
 	"github.com/puppetlabs/relay-core/pkg/expr/model"
+	"github.com/puppetlabs/relay-core/pkg/expr/resolve"
 	"github.com/puppetlabs/relay-core/pkg/expr/testutil"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPath(t *testing.T) {
-	desc, err := fnlib.Library().Descriptor("path")
-	require.NoError(t, err)
+type test struct {
+	Name                    string
+	ObjectArg               interface{}
+	QArg                    interface{}
+	DefaultArg              interface{}
+	Opts                    []evaluate.Option
+	Expected                interface{}
+	ExpectedIncomplete      bool
+	ExpectedPositionalError error
+	ExpectedKeywordError    error
+}
 
-	tests := []struct {
-		Name                    string
-		ObjectArg               interface{}
-		QArg                    string
-		DefaultArg              interface{}
-		Expected                interface{}
-		ExpectedIncomplete      bool
-		ExpectedPositionalError error
-		ExpectedKeywordError    error
-	}{
+type tests []test
+
+func (tts tests) RunAll(t *testing.T) {
+	for _, tt := range tts {
+		t.Run(tt.Name, tt.Run)
+	}
+}
+
+func TestPath(t *testing.T) {
+	tests{
 		{
 			Name: "path exists",
 			ObjectArg: map[string]interface{}{
@@ -77,7 +88,144 @@ func TestPath(t *testing.T) {
 			Expected:   42,
 		},
 		{
-			Name: "path is not resolvable",
+			Name: "path is resolvable (using secrets) and path exists",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": testutil.JSONInvocation("jsonUnmarshal",
+						testutil.JSONSecret("blort")),
+				},
+			},
+			QArg: "foo.bar.grault.garply",
+			Opts: []evaluate.Option{
+				evaluate.WithSecretTypeResolver(resolve.NewMemorySecretTypeResolver(
+					map[string]string{"blort": `{
+						"grault": {
+							"garply": "xyzzy"
+						}
+					}`,
+					},
+				)),
+			},
+			Expected: "xyzzy",
+		},
+		{
+			Name: "path is resolvable (using secrets) and path does not exist",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": testutil.JSONInvocation("jsonUnmarshal",
+						testutil.JSONSecret("blort")),
+				},
+			},
+			QArg: "foo.baz.grault.garply",
+			Opts: []evaluate.Option{
+				evaluate.WithSecretTypeResolver(resolve.NewMemorySecretTypeResolver(
+					map[string]string{"blort": `{
+						"grault": {
+							"garply": "xyzzy"
+						}
+					}`,
+					},
+				)),
+			},
+			DefaultArg: "xyzzy",
+			Expected:   "xyzzy",
+		},
+		{
+			Name: "path is not resolvable (using secrets)",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": testutil.JSONInvocation("jsonUnmarshal",
+						testutil.JSONSecret("blort")),
+				},
+			},
+			QArg:               "foo.bar.grault",
+			ExpectedIncomplete: true,
+		},
+		{
+			Name: "path is resolvable (using connections) and path exists",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": testutil.JSONConnection("blort", "bar"),
+				},
+			},
+			QArg: "foo.bar.grault",
+			Opts: []evaluate.Option{
+				evaluate.WithConnectionTypeResolver(resolve.NewMemoryConnectionTypeResolver(
+					map[resolve.MemoryConnectionKey]interface{}{
+						{Type: "blort", Name: "bar"}: map[string]interface{}{
+							"quuz":   "quux",
+							"grault": "garply",
+						},
+					},
+				)),
+			},
+			Expected: "garply",
+		},
+		{
+			Name: "path is resolvable (using connections) and path does not exist",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"baz": testutil.JSONConnection("blort", "bar"),
+				},
+			},
+			QArg: "foo.bar.grault",
+			Opts: []evaluate.Option{
+				evaluate.WithConnectionTypeResolver(resolve.NewMemoryConnectionTypeResolver(
+					map[resolve.MemoryConnectionKey]interface{}{
+						{Type: "blort", Name: "bar"}: map[string]interface{}{
+							"quuz":   "quux",
+							"grault": "garply",
+						},
+					},
+				)),
+			},
+			DefaultArg: "xyzzy",
+			Expected:   "xyzzy",
+		},
+		{
+			Name: "path is not resolvable (using connections)",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": testutil.JSONConnection("blort", "bar"),
+				},
+			},
+			QArg:               "foo.bar.grault",
+			DefaultArg:         "xyzzy",
+			ExpectedIncomplete: true,
+		},
+		{
+			Name: "path is resolvable (using parameters) and path exists",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": testutil.JSONParameter("quux"),
+				},
+			},
+			QArg: "foo.bar",
+			Opts: []evaluate.Option{
+				evaluate.WithParameterTypeResolver(resolve.NewMemoryParameterTypeResolver(
+					map[string]interface{}{"quux": "baz"},
+				)),
+			},
+			Expected: "baz",
+		},
+		{
+			Name: "path is resolvable (using parameters) and path does not exist",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"quuz": testutil.JSONParameter("quux"),
+				},
+			},
+			QArg: "foo.bar",
+			Opts: []evaluate.Option{
+				evaluate.WithParameterTypeResolver(resolve.NewMemoryParameterTypeResolver(
+					map[string]interface{}{"quux": "baz"},
+				)),
+			},
+			DefaultArg: "grault",
+			Expected:   "grault",
+		},
+		{
+			Name: "path is not resolvable (using parameters)",
 			ObjectArg: map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": testutil.JSONParameter("quux"),
@@ -87,96 +235,159 @@ func TestPath(t *testing.T) {
 			ExpectedIncomplete: true,
 		},
 		{
-			Name: "path is not resolvable with default",
+			Name: "path is not resolvable (using parameters) with default",
 			ObjectArg: map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": testutil.JSONParameter("quux"),
 				},
 			},
-			QArg:       "foo.bar",
-			DefaultArg: 42,
-			Expected:   42,
+			QArg:               "foo.bar",
+			DefaultArg:         42,
+			ExpectedIncomplete: true,
 		},
 		{
-			Name: "path is resolvable but object is not completely resolvable",
+			Name: "path is resolvable (using parameters) but object is not completely resolvable",
 			ObjectArg: map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": testutil.JSONParameter("quux"),
 					"baz": "ok",
 				},
 			},
-			QArg:     "foo.baz",
-			Expected: "ok",
+			QArg:               "foo.baz",
+			ExpectedIncomplete: true,
 		},
 		{
-			Name: "default is not resolvable (falls back to query error)",
+			Name: "query is not resolvable",
 			ObjectArg: map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
 				},
 			},
-			QArg:       "foo.quux",
-			DefaultArg: testutil.JSONParameter("wut"),
+			QArg:               testutil.JSONParameter("wut"),
+			ExpectedIncomplete: true,
+		},
+		{
+			Name: "default is not resolvable",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			QArg:               "foo.quux",
+			DefaultArg:         testutil.JSONParameter("wut"),
+			ExpectedIncomplete: true,
+		},
+		{
+			Name:       "object is unsupported type (nil)",
+			ObjectArg:  nil,
+			QArg:       "foo.bar",
+			DefaultArg: "bar",
 			ExpectedPositionalError: &fn.PositionalArgError{
 				Arg:   1,
-				Cause: &jsonpath.UnknownKeyError{Key: "quux"},
+				Cause: &jsonpath.UnsupportedValueTypeError{Value: nil},
 			},
 			ExpectedKeywordError: &fn.KeywordArgError{
 				Arg:   "object",
-				Cause: &jsonpath.UnknownKeyError{Key: "quux"},
+				Cause: &jsonpath.UnsupportedValueTypeError{Value: nil},
 			},
 		},
-	}
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			t.Run("positional", func(t *testing.T) {
-				args := []model.Evaluable{
-					// Need a real evaluator to test pathing support.
-					evaluate.NewScopedEvaluator(test.ObjectArg),
-					model.StaticEvaluable(test.QArg),
-				}
-				if test.DefaultArg != nil {
-					args = append(args, evaluate.NewScopedEvaluator(test.DefaultArg))
-				}
+		{
+			Name: "object is unsupported type (complex128)",
+			ObjectArg: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": cmplx.Sqrt(12i),
+				},
+			},
+			QArg:       "foo.bar",
+			DefaultArg: "bar",
+			ExpectedPositionalError: &fn.PositionalArgError{
+				Arg: 1,
+				Cause: &evaluate.PathEvaluationError{
+					Path: "foo",
+					Cause: &evaluate.PathEvaluationError{
+						Path: "bar",
+						Cause: &evaluate.UnsupportedValueError{
+							Type: reflect.TypeOf(complex128(1)),
+						},
+					},
+				},
+			},
+			ExpectedKeywordError: &fn.KeywordArgError{
+				Arg: "object",
+				Cause: &evaluate.PathEvaluationError{
+					Path: "foo",
+					Cause: &evaluate.PathEvaluationError{
+						Path: "bar",
+						Cause: &evaluate.UnsupportedValueError{
+							Type: reflect.TypeOf(complex128(1)),
+						},
+					},
+				},
+			},
+		},
+	}.RunAll(t)
+}
 
-				invoker, err := desc.PositionalInvoker(args)
+func (tt test) Run(t *testing.T) {
+	desc, err := fnlib.Library().Descriptor("path")
+	require.NoError(t, err)
+
+	t.Run(tt.Name, func(t *testing.T) {
+		t.Run("positional", func(t *testing.T) {
+			args := []model.Evaluable{
+				// Need a real evaluator to test pathing support.
+				evaluate.NewScopedEvaluator(tt.ObjectArg, tt.Opts...),
+				evaluate.NewScopedEvaluator(tt.QArg, tt.Opts...),
+			}
+			if tt.DefaultArg != nil {
+				args = append(args, evaluate.NewScopedEvaluator(tt.DefaultArg))
+			}
+
+			invoker, err := desc.PositionalInvoker(args)
+			require.NoError(t, err)
+
+			r, err := invoker.Invoke(context.Background())
+			if tt.ExpectedPositionalError != nil {
+				require.Equal(t, tt.ExpectedPositionalError, err)
+			} else {
 				require.NoError(t, err)
-
-				r, err := invoker.Invoke(context.Background())
-				if test.ExpectedPositionalError != nil {
-					require.Equal(t, test.ExpectedPositionalError, err)
-				} else {
-					require.NoError(t, err)
-					require.Equal(t, test.ExpectedIncomplete, !r.Complete())
-					if !test.ExpectedIncomplete {
-						require.Equal(t, test.Expected, r.Value)
-					}
+				require.Equal(t, tt.ExpectedIncomplete, !r.Complete())
+				if !tt.ExpectedIncomplete {
+					require.Equal(t, tt.Expected, r.Value)
 				}
-			})
-
-			t.Run("keyword", func(t *testing.T) {
-				args := map[string]model.Evaluable{
-					"object": evaluate.NewScopedEvaluator(test.ObjectArg),
-					"query":  model.StaticEvaluable(test.QArg),
-				}
-				if test.DefaultArg != nil {
-					args["default"] = evaluate.NewScopedEvaluator(test.DefaultArg)
-				}
-
-				invoker, err := desc.KeywordInvoker(args)
-				require.NoError(t, err)
-
-				r, err := invoker.Invoke(context.Background())
-				if test.ExpectedKeywordError != nil {
-					require.Equal(t, test.ExpectedKeywordError, err)
-				} else {
-					require.NoError(t, err)
-					require.Equal(t, test.ExpectedIncomplete, !r.Complete())
-					if !test.ExpectedIncomplete {
-						require.Equal(t, test.Expected, r.Value)
-					}
-				}
-			})
+			}
 		})
-	}
+
+		t.Run("keyword", func(t *testing.T) {
+			args := map[string]model.Evaluable{
+				"object": evaluate.NewScopedEvaluator(tt.ObjectArg, tt.Opts...),
+				"query":  evaluate.NewScopedEvaluator(tt.QArg, tt.Opts...),
+			}
+			if tt.DefaultArg != nil {
+				args["default"] = evaluate.NewScopedEvaluator(tt.DefaultArg)
+			}
+
+			invoker, err := desc.KeywordInvoker(args)
+			require.NoError(t, err)
+
+			r, err := invoker.Invoke(context.Background())
+			if tt.ExpectedKeywordError != nil {
+				require.Equal(t, tt.ExpectedKeywordError, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.ExpectedIncomplete, !r.Complete())
+				if !tt.ExpectedIncomplete {
+					require.Equal(t, tt.Expected, r.Value)
+				} else {
+					expected := make(map[string]interface{})
+					for k, arg := range args {
+						r, err := arg.EvaluateAll(context.Background())
+						require.NoError(t, err)
+						expected[k] = r.Value
+					}
+					require.Equal(t, expected, r.Value)
+				}
+			}
+		})
+	})
 }

--- a/pkg/expr/model/result.go
+++ b/pkg/expr/model/result.go
@@ -255,8 +255,9 @@ func (r *Result) Complete() bool {
 func (r *Result) Extends(other *Result) *Result {
 	// For convenience, we can copy in the information from another result,
 	// which extends the unresolvables here.
-
-	r.Unresolvable.Extends(other.Unresolvable)
+	if other != nil {
+		r.Unresolvable.Extends(other.Unresolvable)
+	}
 	return r
 }
 
@@ -267,6 +268,10 @@ func CombineResultSlice(s []*Result) *Result {
 	}
 
 	for i, ri := range s {
+		if ri == nil {
+			continue
+		}
+
 		vs[i] = ri.Value
 		r.Extends(ri)
 	}
@@ -281,6 +286,10 @@ func CombineResultMap(m map[string]*Result) *Result {
 	}
 
 	for key, ri := range m {
+		if ri == nil {
+			continue
+		}
+
 		vm[key] = ri.Value
 		r.Extends(ri)
 	}


### PR DESCRIPTION
Function evaluation does not work appropriately with data-oriented evaluables/resolvables (i.e. !Connection, !Secret, !Output, etc.).

Essentially, functions are currently expecting arguments to be fully resolvable at all times when called, and this is not how our system (or the evaluation functionality) works. Functions have to operate the same as any other element and defer processing when used in conjunction with other unresolvables.

This applies most significantly to !Fn.path at the moment, as this is currently the most labor intensive function, but this is a general problem that needs to be fixed before it becomes worse.

We have several different design updates planned (for both the evaluation in general, and the language being used) and this overall functionality is likely to be replaced or refactored in the near future. The goal of this change is primarily to ensure the user functionality we've documented works as advertised in the short-term.

This update addresses a few different issues at hand:
- While the path function was calling EvaluateAll on the object data, this does not get applied, as EvaluateQuery is run against the original Scoped values. EvaluateQuery does not currently evaluate the path before execution (and it probably should). It currently only evaluates the result of the path execution, which is too late in the process. This may be fixed in the future, but that would be a wider change with wider impact that needs to be done carefully. In the meantime, EvaluateAll is now applied to the arguments before ResolveInvocation, which ensures this is handled for all function invocations without relying upon each individual function to correctly handle this. This may or may not change in the future. Worst-case, this results in repeated calls to EvaluateAll on function arguments, but in terms of robustness and reliability, this helps ensure that the onus is not always on each and every function to handle this properly.
- The argument evaluation was short-circuiting if any arguments were incomplete. However, the subsequent code tries to rebuild the function based on the argument results. Not all the values may have been evaluated due to the short-circuit logic (i.e. if the object is not complete, it will immediately return nil without evaluating either the query or the default). This was breaking much of the subsequent logic. The logic now will only short-circuit on error, and will evaluate all arguments before checking for completion. There are multiple ways to handle this properly, but the current changes are probably the least impactful given the current design.
- Previously, any defaults would be applied in Unresolvables were present, but this is not the intended behavior. Resolvables should be completed prior to running the query or applying default handling. Defaults should only be processed if the query path is not found or other similar issues with the data itself.
- The path function was only calling Evaluate and not EvaluateAll for argument handling. This meant that syntax errors in embedded structures/data were not being caught properly, and would cause cascading issues.