### PR TITLE
Add environment to workflow types

### DIFF
--- a/pkg/workflow/types/v1/decoder.go
+++ b/pkg/workflow/types/v1/decoder.go
@@ -135,6 +135,7 @@ func yamlWorkflowDataToWorkflowData(ywd *YAMLWorkflowData) (*WorkflowData, error
 					ContainerMixin: ContainerMixin{
 						Image:     step.Image,
 						Spec:      makeJSONTreeMap(step.Spec),
+						Env:       makeJSONTreeMap(step.Env),
 						InputFile: step.InputFile,
 						Input:     step.Input,
 						Command:   step.Command,
@@ -177,6 +178,7 @@ func yamlWorkflowDataToWorkflowData(ywd *YAMLWorkflowData) (*WorkflowData, error
 					ContainerMixin: ContainerMixin{
 						Image:     trigger.Source.Image,
 						Spec:      makeJSONTreeMap(trigger.Source.Spec),
+						Env:       makeJSONTreeMap(trigger.Source.Env),
 						InputFile: trigger.Source.InputFile,
 						Input:     trigger.Source.Input,
 						Command:   trigger.Source.Command,

--- a/pkg/workflow/types/v1/decoder_test.go
+++ b/pkg/workflow/types/v1/decoder_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/puppetlabs/relay-core/pkg/expr/serialize"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,6 +28,13 @@ func validWorkflow(t *testing.T, wd *WorkflowData) {
 				Variant: &ContainerWorkflowStep{
 					ContainerMixin: ContainerMixin{
 						Image: "image-1",
+						Spec: ExpressionMap{
+							"tag": serialize.JSONTree{Tree: "v1"},
+						},
+						Env: ExpressionMap{
+							"CI":      serialize.JSONTree{Tree: true},
+							"RETRIES": serialize.JSONTree{Tree: 3},
+						},
 					},
 				},
 			},

--- a/pkg/workflow/types/v1/testdata/valid.yaml
+++ b/pkg/workflow/types/v1/testdata/valid.yaml
@@ -7,4 +7,8 @@ parameters:
 steps:
   - name: step-1
     image: image-1
-    
+    env:
+      CI: true
+      RETRIES: 3
+    spec:
+      tag: v1

--- a/pkg/workflow/types/v1/types.go
+++ b/pkg/workflow/types/v1/types.go
@@ -63,6 +63,7 @@ type YAMLWorkflowTrigger struct {
 type YAMLContainerMixin struct {
 	Image     string                        `yaml:"image" json:"image,omitempty"`
 	Spec      map[string]serialize.YAMLTree `yaml:"spec" json:"spec,omitempty"`
+	Env       map[string]serialize.YAMLTree `yaml:"env" json:"env,omitempty"`
 	Input     []string                      `yaml:"input" json:"input,omitempty"`
 	InputFile string                        `yaml:"inputFile" json:"inputFile,omitempty"`
 	Command   string                        `yaml:"command" json:"command,omitempty"`
@@ -207,6 +208,7 @@ type WorkflowStepVariant interface {
 type ContainerMixin struct {
 	Image     string        `yaml:"image" json:"image"`
 	Spec      ExpressionMap `yaml:"spec" json:"spec,omitempty"`
+	Env       ExpressionMap `yaml:"env" json:"env,omitempty"`
 	InputFile string        `yaml:"inputFile" json:"inputFile,omitempty"`
 	Input     []string      `yaml:"input" json:"input,omitempty"`
 	Command   string        `yaml:"command" json:"command,omitempty"`

--- a/pkg/workflow/types/v1/webhooktriggermapping.go
+++ b/pkg/workflow/types/v1/webhooktriggermapping.go
@@ -61,7 +61,8 @@ func (m *DefaultWebhookTriggerEngineMapper) ToRuntimeObjectsManifest(tenant *v1b
 			Input:   source.Input,
 			Command: source.Command,
 			Args:    source.Args,
-			Spec:    mapStepSpec(source.Spec),
+			Spec:    mapSpec(source.Spec),
+			Env:     mapSpec(source.Env),
 		},
 	}
 

--- a/pkg/workflow/types/v1/webhooktriggermapping_test.go
+++ b/pkg/workflow/types/v1/webhooktriggermapping_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/puppetlabs/relay-core/pkg/expr/serialize"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,6 +27,13 @@ func TestWebhookTriggerMapping(t *testing.T) {
 	source := &WebhookWorkflowTriggerSource{
 		ContainerMixin: ContainerMixin{
 			Image: "test-image:latest",
+			Spec: ExpressionMap{
+				"tag": serialize.JSONTree{Tree: "v1"},
+			},
+			Env: ExpressionMap{
+				"CI":      serialize.JSONTree{Tree: true},
+				"RETRIES": serialize.JSONTree{Tree: 3},
+			},
 		},
 	}
 
@@ -34,4 +42,7 @@ func TestWebhookTriggerMapping(t *testing.T) {
 
 	require.NotNil(t, manifest.WebhookTrigger)
 	require.Equal(t, tenant.Tenant.GetNamespace(), manifest.WebhookTrigger.GetNamespace())
+
+	require.Len(t, manifest.WebhookTrigger.Spec.Spec, 1)
+	require.Len(t, manifest.WebhookTrigger.Spec.Env, 2)
 }

--- a/pkg/workflow/types/v1/workflowrunmapping.go
+++ b/pkg/workflow/types/v1/workflowrunmapping.go
@@ -161,7 +161,8 @@ func mapSteps(wd *WorkflowData) []*nebulav1.WorkflowStep {
 		switch variant := value.Variant.(type) {
 		case *ContainerWorkflowStep:
 			workflowStep.Image = variant.Image
-			workflowStep.Spec = mapStepSpec(variant.Spec)
+			workflowStep.Spec = mapSpec(variant.Spec)
+			workflowStep.Env = mapSpec(variant.Env)
 			workflowStep.Input = variant.Input
 			workflowStep.Command = variant.Command
 			workflowStep.Args = variant.Args
@@ -173,7 +174,7 @@ func mapSteps(wd *WorkflowData) []*nebulav1.WorkflowStep {
 	return workflowSteps
 }
 
-func mapStepSpec(jm map[string]serialize.JSONTree) v1beta1.UnstructuredObject {
+func mapSpec(jm map[string]serialize.JSONTree) v1beta1.UnstructuredObject {
 	uo := make(v1beta1.UnstructuredObject, len(jm))
 	for k, v := range jm {
 		// The inner data type has to be compatible with transfer.JSONInterface

--- a/pkg/workflow/types/v1/workflowrunmapping_test.go
+++ b/pkg/workflow/types/v1/workflowrunmapping_test.go
@@ -36,5 +36,8 @@ func TestWorkflowRunEngineMapping(t *testing.T) {
 	require.Equal(t, "valid-workflow-name", manifest.WorkflowRun.Spec.Workflow.Name)
 
 	require.Len(t, manifest.WorkflowRun.Spec.Workflow.Steps, 1)
+	require.Len(t, manifest.WorkflowRun.Spec.Workflow.Steps[0].Spec, 1)
+	require.Len(t, manifest.WorkflowRun.Spec.Workflow.Steps[0].Env, 2)
+
 	require.Len(t, manifest.WorkflowRun.Spec.Workflow.Parameters, 1)
 }


### PR DESCRIPTION
Environment variable handling was added to Relay API prior to this code being copied into Relay Core, but the changes happened at roughly the same time and were not integrated. One of the many dangers of having duplicated code.