### PR TITLE
Only attempt to enforce pod requirements during the creation phase

### DIFF
--- a/pkg/operator/admission/podenforcement.go
+++ b/pkg/operator/admission/podenforcement.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -45,6 +46,10 @@ var _ admission.Handler = &PodEnforcementHandler{}
 var _ admission.DecoderInjector = &PodEnforcementHandler{}
 
 func (peh *PodEnforcementHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Create {
+		return admission.Allowed("")
+	}
+
 	pod := &corev1.Pod{}
 	if err := peh.decoder.Decode(req, pod); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/operator/admission/volumeclaim.go
+++ b/pkg/operator/admission/volumeclaim.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/puppetlabs/relay-core/pkg/model"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -23,6 +24,10 @@ var _ admission.Handler = &VolumeClaimHandler{}
 var _ admission.DecoderInjector = &VolumeClaimHandler{}
 
 func (eh *VolumeClaimHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Create {
+		return admission.Allowed("")
+	}
+
 	pod := &corev1.Pod{}
 	if err := eh.decoder.Decode(req, pod); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)


### PR DESCRIPTION
Most fields of a pod are immutable after creation, so if you change the configuration (e.g., enabling sandboxing) in the middle of a workflow run, the pods that have the old configuration will get stuck in an update loop that will cause them to sit around waiting forever.