### PR TITLE
Remove name-based labels

### DIFF
--- a/pkg/workflow/types/v1/enginemapping.go
+++ b/pkg/workflow/types/v1/enginemapping.go
@@ -7,11 +7,9 @@ import (
 )
 
 const (
-	AccountIDLabel           = "managed.relay.sh/account-id"
-	WorkflowIDLabel          = "managed.relay.sh/workflow-id"
-	WorkflowNameLabel        = "managed.relay.sh/workflow-name"
-	WorkflowTriggerIDLabel   = "managed.relay.sh/workflow-trigger-id"
-	WorkflowTriggerNameLabel = "managed.relay.sh/workflow-trigger-name"
+	AccountIDLabel         = "managed.relay.sh/account-id"
+	WorkflowIDLabel        = "managed.relay.sh/workflow-id"
+	WorkflowTriggerIDLabel = "managed.relay.sh/workflow-trigger-id"
 )
 
 const (

--- a/pkg/workflow/types/v1/tenantmapping.go
+++ b/pkg/workflow/types/v1/tenantmapping.go
@@ -88,17 +88,14 @@ func (m *DefaultTenantEngineMapper) ToRuntimeObjectsManifest() (*TenantKubernete
 		namespace = mapNamespace(m.namespace)
 	}
 
-	labels := map[string]string{
-		AccountIDLabel:    m.id,
-		WorkflowIDLabel:   m.workflowID,
-		WorkflowNameLabel: m.workflowName,
-	}
-
 	tenant := &v1beta1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   m.namespace,
-			Labels:      labels,
+			Name:      name,
+			Namespace: m.namespace,
+			Labels: map[string]string{
+				AccountIDLabel:  m.id,
+				WorkflowIDLabel: m.workflowID,
+			},
 			Annotations: map[string]string{},
 		},
 		Spec: v1beta1.TenantSpec{

--- a/pkg/workflow/types/v1/webhooktriggermapping.go
+++ b/pkg/workflow/types/v1/webhooktriggermapping.go
@@ -78,8 +78,7 @@ func (m *DefaultWebhookTriggerEngineMapper) ToRuntimeObjectsManifest(tenant *v1b
 			Name:      fmt.Sprintf("trigger-%s", m.id),
 			Namespace: tenant.GetNamespace(),
 			Labels: map[string]string{
-				WorkflowTriggerIDLabel:   m.id,
-				WorkflowTriggerNameLabel: m.name,
+				WorkflowTriggerIDLabel: m.id,
 			},
 			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{


### PR DESCRIPTION
Removes name-based labels (as labels have strict naming requirements). We don't want to have a requirement that these are sanitized, for a variety of reasons. We do not currently use these labels anywhere. Trigger names are already available as part of the `WebhookTrigger` spec, additionally.
