### PR TITLE
Fix RBAC permissions for relay-installer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/puppetlabs/leg/httputil v0.1.4
 	github.com/puppetlabs/leg/instrumentation v0.1.4
 	github.com/puppetlabs/leg/jsonutil v0.2.0
-	github.com/puppetlabs/leg/k8sutil v0.4.0
+	github.com/puppetlabs/leg/k8sutil v0.4.1
 	github.com/puppetlabs/leg/logging v0.1.0
 	github.com/puppetlabs/leg/mainutil v0.1.2
 	github.com/puppetlabs/leg/scheduler v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1288,6 +1288,8 @@ github.com/puppetlabs/leg/jsonutil v0.2.0 h1:Hp21b/bVlEQET6PkHRXCZnUix3ujwfJuR92
 github.com/puppetlabs/leg/jsonutil v0.2.0/go.mod h1:eiLGPpySpr87IiROi0e4WZcqc7bo0ucs23sjdyOwH9Q=
 github.com/puppetlabs/leg/k8sutil v0.4.0 h1:DGGOOrJoiUte4V0o9HJu51+Zb2bzN0lHaDBIfIq9Ri8=
 github.com/puppetlabs/leg/k8sutil v0.4.0/go.mod h1:5LN5B926v3QNyCQa8IYYIoFS+4f2ak2Mg0LHdIPFQZU=
+github.com/puppetlabs/leg/k8sutil v0.4.1 h1:TDsM3ELl9vESfyhtTpOn8dRrZBjNHe9ZsjuDO1wiJjg=
+github.com/puppetlabs/leg/k8sutil v0.4.1/go.mod h1:5LN5B926v3QNyCQa8IYYIoFS+4f2ak2Mg0LHdIPFQZU=
 github.com/puppetlabs/leg/lifecycle v0.2.0 h1:WYaQF+mdW8Wy+tRHkEE9175Bhkd3zJ7i0qnOQkb+BmY=
 github.com/puppetlabs/leg/lifecycle v0.2.0/go.mod h1:QtYNNukWpkcLWZAWcM9tVxcWfqn9mULH5J3dCkMqzGk=
 github.com/puppetlabs/leg/logging v0.1.0 h1:G8M2w3izYEtoaH+d3rIJZ9iLX2oW2T/jO+J4l+T0Ieo=

--- a/manifests/resources/role.yaml
+++ b/manifests/resources/role.yaml
@@ -29,26 +29,11 @@ rules:
   - update
   - watch
 - apiGroups:
-  - batch
-  - extensions
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
   - limitranges
   - namespaces
-  - persistentvolumeclaims
-  - persistentvolumes
   - secrets
   - serviceaccounts
   - services
@@ -113,6 +98,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - pvpool.puppet.com
+  resources:
+  - checkouts
+  - checkouts/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -153,6 +147,7 @@ rules:
 - apiGroups:
   - serving.knative.dev
   resources:
+  - revisions
   - services
   verbs:
   - create

--- a/pkg/install/config/rbac/role.yaml
+++ b/pkg/install/config/rbac/role.yaml
@@ -29,26 +29,11 @@ rules:
   - update
   - watch
 - apiGroups:
-  - batch
-  - extensions
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
   - limitranges
   - namespaces
-  - persistentvolumeclaims
-  - persistentvolumes
   - secrets
   - serviceaccounts
   - services
@@ -113,6 +98,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - pvpool.puppet.com
+  resources:
+  - checkouts
+  - checkouts/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -153,6 +147,7 @@ rules:
 - apiGroups:
   - serving.knative.dev
   resources:
+  - revisions
   - services
   verbs:
   - create

--- a/pkg/install/controller/operatorstate.go
+++ b/pkg/install/controller/operatorstate.go
@@ -275,8 +275,6 @@ func (m *operatorStateManager) deploymentCommand() []string {
 		"relay-operator",
 		"-environment",
 		m.rc.Spec.Environment,
-		"-tool-injection-image",
-		m.rc.Spec.Operator.ToolInjection.Image,
 		"-num-workers",
 		strconv.Itoa(int(m.rc.Spec.Operator.Workers)),
 		"-jwt-signing-key-file",
@@ -428,7 +426,7 @@ func (m *operatorStateManager) clusterRole(clusterRole *rbacv1.ClusterRole) {
 	clusterRole.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
-			Resources: []string{"namespaces", "persistentvolumes", "persistentvolumeclaims"},
+			Resources: []string{"namespaces"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
@@ -440,11 +438,6 @@ func (m *operatorStateManager) clusterRole(clusterRole *rbacv1.ClusterRole) {
 			APIGroups: []string{"tekton.dev"},
 			Resources: []string{"pipelineruns", "taskruns", "pipelines", "tasks", "conditions"},
 			Verbs:     []string{"get", "list", "watch"},
-		},
-		{
-			APIGroups: []string{"batch", "extensions"},
-			Resources: []string{"jobs"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
 			APIGroups: []string{"rbac.authorization.k8s.io"},
@@ -462,13 +455,18 @@ func (m *operatorStateManager) clusterRole(clusterRole *rbacv1.ClusterRole) {
 			Verbs:     []string{"get", "list", "watch", "update", "patch"},
 		},
 		{
+			APIGroups: []string{"pvpool.puppet.com"},
+			Resources: []string{"checkouts"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
 			APIGroups: []string{"relay.sh"},
 			Resources: []string{"tenants", "tenants/status", "webhooktriggers", "webhooktriggers/status"},
 			Verbs:     []string{"get", "list", "watch", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"serving.knative.dev"},
-			Resources: []string{"services"},
+			Resources: []string{"revisions", "services"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
@@ -483,7 +481,7 @@ func (m *operatorStateManager) delegateClusterRole(clusterRole *rbacv1.ClusterRo
 		},
 		{
 			APIGroups: []string{""},
-			Resources: []string{"configmaps", "serviceaccounts", "secrets", "limitranges", "persistentvolumeclaims"},
+			Resources: []string{"configmaps", "serviceaccounts", "secrets", "limitranges"},
 			Verbs:     []string{"create", "update", "patch", "delete"},
 		},
 		{
@@ -503,7 +501,7 @@ func (m *operatorStateManager) delegateClusterRole(clusterRole *rbacv1.ClusterRo
 		},
 		{
 			APIGroups: []string{"serving.knative.dev"},
-			Resources: []string{"services"},
+			Resources: []string{"revisions", "services"},
 			Verbs:     []string{"create", "update", "patch", "delete"},
 		},
 	}

--- a/pkg/install/controller/relaycorecontroller.go
+++ b/pkg/install/controller/relaycorecontroller.go
@@ -51,18 +51,18 @@ type RelayCoreReconciler struct {
 
 // +kubebuilder:rbac:groups=install.relay.sh,resources=relaycores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=install.relay.sh,resources=relaycores/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=core,resources=configmaps;limitranges;serviceaccounts;services;secrets;namespaces;persistentvolumes;persistentvolumeclaims,verbs=get;list;watch;patch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps;limitranges;serviceaccounts;services;secrets;namespaces,verbs=get;list;watch;patch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=pods;pods/log,verbs=get;list;watch
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns;taskruns;pipelines;tasks;conditions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=batch;extensions,resources=jobs,verbs=get;list;watch;patch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch;create;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;patch;create;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfiguration,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nebula.puppet.com,resources=workflowruns;workflowruns/status,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=pvpool.puppet.com,resources=checkouts;checkouts/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=relay.sh,resources=tenants;tenants/status;webhooktriggers;webhooktriggers/status,verbs=get;list;watch;patch;update
-// +kubebuilder:rbac:groups=serving.knative.dev,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.knative.dev,resources=revisions;services,verbs=get;list;watch;create;update;patch;delete
 
 func (r *RelayCoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("relaycore", req.NamespacedName)

--- a/pkg/install/controller/vaultagentstate.go
+++ b/pkg/install/controller/vaultagentstate.go
@@ -109,6 +109,10 @@ func (m *vaultAgentManager) getRole() string {
 	role := fmt.Sprintf("%s-%s", m.rc.Name, m.component.String())
 
 	switch m.component {
+	case componentLogService:
+		if m.rc.Spec.LogService.VaultAgentRole != nil {
+			role = *m.rc.Spec.LogService.VaultAgentRole
+		}
 	case componentOperator:
 		if m.rc.Spec.Operator.VaultAgentRole != nil {
 			role = *m.rc.Spec.Operator.VaultAgentRole

--- a/scripts/build
+++ b/scripts/build
@@ -23,9 +23,11 @@ do_build() {
   else
     (
       set -x
+      GO_PKG_DIR=$(go env GOPATH)/pkg
+      [ ! -d "$GO_PKG_DIR" ] && mkdir -p "$GO_PKG_DIR"
       buildah bud \
         "${BUILD_ARGS[@]}" \
-        -v "$(go env GOPATH)/pkg:/go/pkg:O" \
+        -v "$GO_PKG_DIR:/go/pkg:O" \
         .
       buildah push "${BUILD_IMAGE}" "docker-daemon:${BUILD_IMAGE}"
     )


### PR DESCRIPTION
* Removes legacy RBAC permissions (PVs, PVCs, Jobs)
* Adds new PVPool Checkout RBAC permissions
* Adds Knative Revisions RBAC permissions
* Removes legacy `-tool-injection-image` configuration option (preventing the dev environment from functioning).
* Adds missing (but unused) setting for optional manual configuration of the LogService vault role