### PR TITLE
Bring back unresolvable data to improve validation

### DIFF
--- a/pkg/expr/evaluate/mapping.go
+++ b/pkg/expr/evaluate/mapping.go
@@ -29,7 +29,14 @@ func evaluateType(ctx context.Context, tm map[string]interface{}, o *Options) (*
 		}
 
 		d, err := resolver.ResolveData(ctx)
-		if err != nil {
+		if _, ok := err.(*model.DataNotFoundError); ok {
+			return &model.Result{
+				Value: tm,
+				Unresolvable: model.Unresolvable{Data: []model.UnresolvableData{
+					{Name: name},
+				}},
+			}, nil
+		} else if err != nil {
 			return nil, &InvalidTypeError{Type: "Data", Cause: err}
 		}
 

--- a/pkg/expr/model/errors.go
+++ b/pkg/expr/model/errors.go
@@ -21,6 +21,18 @@ func (e *UnresolvableError) Error() string {
 	return fmt.Sprintf("unresolvable:\n%s", strings.Join(causes, "\n"))
 }
 
+type DataNotFoundError struct {
+	Name string
+}
+
+func (e *DataNotFoundError) Error() string {
+	if e.Name == "" {
+		return "model: data could not be found"
+	}
+
+	return fmt.Sprintf("model: %s data could not be found", e.Name)
+}
+
 type SecretNotFoundError struct {
 	Name string
 }

--- a/pkg/expr/model/result_json.go
+++ b/pkg/expr/model/result_json.go
@@ -2,6 +2,10 @@ package model
 
 import "github.com/puppetlabs/leg/encoding/transfer"
 
+type JSONUnresolvableDataEnvelope struct {
+	Name string `json:"name"`
+}
+
 type JSONUnresolvableSecretEnvelope struct {
 	Name string `json:"name"`
 }
@@ -30,6 +34,7 @@ type JSONUnresolvableInvocationEnvelope struct {
 }
 
 type JSONUnresolvableEnvelope struct {
+	Data        []*JSONUnresolvableDataEnvelope       `json:"data,omitempty"`
 	Secrets     []*JSONUnresolvableSecretEnvelope     `json:"secrets,omitempty"`
 	Connections []*JSONUnresolvableConnectionEnvelope `json:"connections,omitempty"`
 	Outputs     []*JSONUnresolvableOutputEnvelope     `json:"outputs,omitempty"`
@@ -40,6 +45,15 @@ type JSONUnresolvableEnvelope struct {
 
 func NewJSONUnresolvableEnvelope(ur Unresolvable) *JSONUnresolvableEnvelope {
 	env := &JSONUnresolvableEnvelope{}
+
+	if len(ur.Data) > 0 {
+		env.Data = make([]*JSONUnresolvableDataEnvelope, len(ur.Data))
+		for i, d := range ur.Data {
+			env.Data[i] = &JSONUnresolvableDataEnvelope{
+				Name: d.Name,
+			}
+		}
+	}
 
 	if len(ur.Secrets) > 0 {
 		env.Secrets = make([]*JSONUnresolvableSecretEnvelope, len(ur.Secrets))

--- a/pkg/expr/pathlang/adapter.go
+++ b/pkg/expr/pathlang/adapter.go
@@ -20,7 +20,11 @@ var (
 
 func (dtra *DataTypeResolverAdapter) Index(ctx context.Context, idx interface{}) (interface{}, error) {
 	d, err := dtra.ResolveData(ctx)
-	if err != nil {
+	if errmark.Matches(err, errmark.RuleType(&model.DataNotFoundError{})) {
+		return model.StaticExpandable(nil, model.Unresolvable{
+			Data: []model.UnresolvableData{{}},
+		}), nil
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/pkg/expr/resolve/noop.go
+++ b/pkg/expr/resolve/noop.go
@@ -1,6 +1,19 @@
 package resolve
 
+import (
+	"context"
+
+	"github.com/puppetlabs/relay-core/pkg/expr/model"
+)
+
+type noOpDataTypeResolver struct{}
+
+func (*noOpDataTypeResolver) ResolveData(ctx context.Context) (interface{}, error) {
+	return nil, &model.DataNotFoundError{}
+}
+
 var (
+	NoOpDataTypeResolver       DataTypeResolver       = &noOpDataTypeResolver{}
 	NoOpSecretTypeResolver     SecretTypeResolver     = NewMemorySecretTypeResolver(map[string]string{})
 	NoOpConnectionTypeResolver ConnectionTypeResolver = NewMemoryConnectionTypeResolver(map[MemoryConnectionKey]interface{}{})
 	NoOpOutputTypeResolver     OutputTypeResolver     = NewMemoryOutputTypeResolver(map[MemoryOutputKey]interface{}{})


### PR DESCRIPTION
It turns out that we actually need specific data (not the query itself) to be unresolvable so that we can validate the structure of a workflow without event data being passed in to it. This change brings back the unresolvable field and adds a NoOpDataTypeResolver that always returns a not found error.