### PR TITLE
Split tool injection pools

### DIFF
--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -11,19 +11,20 @@ import (
 // WorkflowControllerConfig is the configuration object used to
 // configure the Workflow controller.
 type WorkflowControllerConfig struct {
-	Environment             string
-	Standalone              bool
-	Namespace               string
-	ImagePullSecret         string
-	MaxConcurrentReconciles int
-	MetadataAPIURL          *url.URL
-	VaultTransitPath        string
-	VaultTransitKey         string
-	WebhookServerPort       int
-	WebhookServerKeyDir     string
-	DynamicRBACBinding      bool
-	ToolInjectionPool       client.ObjectKey
-	AlertsDelegate          alerts.DelegateFunc
+	Environment               string
+	Standalone                bool
+	Namespace                 string
+	ImagePullSecret           string
+	MaxConcurrentReconciles   int
+	MetadataAPIURL            *url.URL
+	VaultTransitPath          string
+	VaultTransitKey           string
+	WebhookServerPort         int
+	WebhookServerKeyDir       string
+	DynamicRBACBinding        bool
+	TriggerToolInjectionPool  client.ObjectKey
+	WorkflowToolInjectionPool client.ObjectKey
+	AlertsDelegate            alerts.DelegateFunc
 }
 
 func (c *WorkflowControllerConfig) Capturer() trackers.Capturer {

--- a/pkg/operator/reconciler/trigger/reconciler.go
+++ b/pkg/operator/reconciler/trigger/reconciler.go
@@ -74,8 +74,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		r.Config.MetadataAPIURL,
 		app.WebhookTriggerDepsWithStandaloneMode(r.Config.Standalone),
 		app.WebhookTriggerDepsWithToolInjectionPool(pvpoolv1alpha1.PoolReference{
-			Namespace: r.Config.ToolInjectionPool.Namespace,
-			Name:      r.Config.ToolInjectionPool.Name,
+			Namespace: r.Config.TriggerToolInjectionPool.Namespace,
+			Name:      r.Config.TriggerToolInjectionPool.Name,
 		}),
 	)
 	loaded, err := deps.Load(ctx, r.Client)

--- a/pkg/operator/reconciler/workflow/reconciler.go
+++ b/pkg/operator/reconciler/workflow/reconciler.go
@@ -89,8 +89,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			r.Config.MetadataAPIURL,
 			app.WorkflowRunDepsWithStandaloneMode(r.Config.Standalone),
 			app.WorkflowRunDepsWithToolInjectionPool(pvpoolv1alpha1.PoolReference{
-				Namespace: r.Config.ToolInjectionPool.Namespace,
-				Name:      r.Config.ToolInjectionPool.Name,
+				Namespace: r.Config.WorkflowToolInjectionPool.Namespace,
+				Name:      r.Config.WorkflowToolInjectionPool.Name,
 			}),
 		)
 

--- a/tests/e2e/e2econfig_test.go
+++ b/tests/e2e/e2econfig_test.go
@@ -322,7 +322,8 @@ func doConfigDependencyManager(ctx context.Context) doConfigFunc {
 			}
 			require.NoError(t, pool.Persist(ctx, cfg.Environment.ControllerClient))
 
-			wcc.ToolInjectionPool = pool.Key
+			wcc.TriggerToolInjectionPool = pool.Key
+			wcc.WorkflowToolInjectionPool = pool.Key
 		}
 
 		deps, err := dependency.NewDependencyManager(wcc, cfg.Environment.RESTConfig, cfg.Vault.Client, cfg.Vault.JWTSigner, cfg.blobStore, metrics)


### PR DESCRIPTION
Splits the tool injection pool configuration into two different separate options for triggers and workflows. The same pool can be used for both if desired.

Trigger pods do not change with the same frequency as workflows. Particularly when disabling scale-to-zero.
Having a separate, more static pool for triggers will make it easier to maintain and manage the more volatile workflow pool, as it constantly changes as workflow runs are initiated.

Additionally, as part of short-term improvements to workflow start time, the workflow pool will be disabled (soon) and the trigger pool will remain as-is in order to ensure trigger logs are captured.