### PR TITLE
Add additional function to list outputs by step

### DIFF
--- a/pkg/manager/configmap/stepoutput.go
+++ b/pkg/manager/configmap/stepoutput.go
@@ -56,6 +56,25 @@ func (m *StepOutputManager) List(ctx context.Context) ([]*model.StepOutput, erro
 	return l, nil
 }
 
+func (m *StepOutputManager) ListByStep(ctx context.Context) ([]*model.StepOutput, error) {
+	som, err := m.kcm.List(ctx, fmt.Sprintf("%s.%s.output.", model.ActionTypeStep.Plural, m.me.Hash().HexEncoding()))
+	if err != nil {
+		return nil, err
+	}
+
+	var l []*model.StepOutput
+
+	for key, value := range som {
+		l = append(l, &model.StepOutput{
+			Step:  m.me,
+			Name:  key,
+			Value: value,
+		})
+	}
+
+	return l, nil
+}
+
 func (m *StepOutputManager) Get(ctx context.Context, stepName, name string) (*model.StepOutput, error) {
 	step := &model.Step{
 		Run:  m.me.Run,

--- a/pkg/manager/configmap/stepoutput.go
+++ b/pkg/manager/configmap/stepoutput.go
@@ -56,7 +56,7 @@ func (m *StepOutputManager) List(ctx context.Context) ([]*model.StepOutput, erro
 	return l, nil
 }
 
-func (m *StepOutputManager) ListByStep(ctx context.Context) ([]*model.StepOutput, error) {
+func (m *StepOutputManager) ListSelf(ctx context.Context) ([]*model.StepOutput, error) {
 	som, err := m.kcm.List(ctx, fmt.Sprintf("%s.%s.output.", model.ActionTypeStep.Plural, m.me.Hash().HexEncoding()))
 	if err != nil {
 		return nil, err

--- a/pkg/manager/configmap/stepoutput_test.go
+++ b/pkg/manager/configmap/stepoutput_test.go
@@ -36,6 +36,17 @@ func TestStepOutputManager(t *testing.T) {
 	_, err = om1.Set(ctx, "key-b", "value-b-step-1")
 	require.NoError(t, err)
 
+	outs, err := om1.ListByStep(ctx)
+	require.NoError(t, err)
+	require.Len(t, outs, 2)
+	require.Contains(t, outs, &model.StepOutput{Step: step1, Name: "key-a", Value: "value-a-step-1"})
+	require.Contains(t, outs, &model.StepOutput{Step: step1, Name: "key-b", Value: "value-b-step-1"})
+
+	outs, err = om2.ListByStep(ctx)
+	require.NoError(t, err)
+	require.Len(t, outs, 1)
+	require.Contains(t, outs, &model.StepOutput{Step: step2, Name: "key-a", Value: "value-a-step-2"})
+
 	for i, om := range []model.StepOutputManager{om1, om2} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			out, err := om.Get(ctx, step1.Name, "key-a")

--- a/pkg/manager/configmap/stepoutput_test.go
+++ b/pkg/manager/configmap/stepoutput_test.go
@@ -36,13 +36,13 @@ func TestStepOutputManager(t *testing.T) {
 	_, err = om1.Set(ctx, "key-b", "value-b-step-1")
 	require.NoError(t, err)
 
-	outs, err := om1.ListByStep(ctx)
+	outs, err := om1.ListSelf(ctx)
 	require.NoError(t, err)
 	require.Len(t, outs, 2)
 	require.Contains(t, outs, &model.StepOutput{Step: step1, Name: "key-a", Value: "value-a-step-1"})
 	require.Contains(t, outs, &model.StepOutput{Step: step1, Name: "key-b", Value: "value-b-step-1"})
 
-	outs, err = om2.ListByStep(ctx)
+	outs, err = om2.ListSelf(ctx)
 	require.NoError(t, err)
 	require.Len(t, outs, 1)
 	require.Contains(t, outs, &model.StepOutput{Step: step2, Name: "key-a", Value: "value-a-step-2"})

--- a/pkg/manager/memory/stepoutput.go
+++ b/pkg/manager/memory/stepoutput.go
@@ -79,6 +79,27 @@ func (m *StepOutputManager) List(ctx context.Context) ([]*model.StepOutput, erro
 	return l, nil
 }
 
+func (m *StepOutputManager) ListByStep(ctx context.Context) ([]*model.StepOutput, error) {
+	var l []*model.StepOutput
+
+	for _, key := range m.m.Keys() {
+		value, found := m.m.Get(key)
+		if !found {
+			continue
+		}
+
+		if key.StepName == m.me.Name {
+			l = append(l, &model.StepOutput{
+				Step:  m.me,
+				Name:  key.Name,
+				Value: value,
+			})
+		}
+	}
+
+	return l, nil
+}
+
 func (m *StepOutputManager) Get(ctx context.Context, stepName, name string) (*model.StepOutput, error) {
 	step := &model.Step{
 		Run:  m.me.Run,

--- a/pkg/manager/memory/stepoutput.go
+++ b/pkg/manager/memory/stepoutput.go
@@ -79,7 +79,7 @@ func (m *StepOutputManager) List(ctx context.Context) ([]*model.StepOutput, erro
 	return l, nil
 }
 
-func (m *StepOutputManager) ListByStep(ctx context.Context) ([]*model.StepOutput, error) {
+func (m *StepOutputManager) ListSelf(ctx context.Context) ([]*model.StepOutput, error) {
 	var l []*model.StepOutput
 
 	for _, key := range m.m.Keys() {

--- a/pkg/manager/reject/stepoutput.go
+++ b/pkg/manager/reject/stepoutput.go
@@ -12,6 +12,10 @@ func (*stepOutputManager) List(ctx context.Context) ([]*model.StepOutput, error)
 	return nil, model.ErrRejected
 }
 
+func (*stepOutputManager) ListByStep(ctx context.Context) ([]*model.StepOutput, error) {
+	return nil, model.ErrRejected
+}
+
 func (*stepOutputManager) Get(ctx context.Context, stepName, name string) (*model.StepOutput, error) {
 	return nil, model.ErrRejected
 }

--- a/pkg/manager/reject/stepoutput.go
+++ b/pkg/manager/reject/stepoutput.go
@@ -12,7 +12,7 @@ func (*stepOutputManager) List(ctx context.Context) ([]*model.StepOutput, error)
 	return nil, model.ErrRejected
 }
 
-func (*stepOutputManager) ListByStep(ctx context.Context) ([]*model.StepOutput, error) {
+func (*stepOutputManager) ListSelf(ctx context.Context) ([]*model.StepOutput, error) {
 	return nil, model.ErrRejected
 }
 

--- a/pkg/model/stepoutput.go
+++ b/pkg/model/stepoutput.go
@@ -12,6 +12,7 @@ type StepOutput struct {
 
 type StepOutputGetterManager interface {
 	List(ctx context.Context) ([]*StepOutput, error)
+	ListByStep(ctx context.Context) ([]*StepOutput, error)
 	Get(ctx context.Context, stepName, name string) (*StepOutput, error)
 }
 

--- a/pkg/model/stepoutput.go
+++ b/pkg/model/stepoutput.go
@@ -12,7 +12,7 @@ type StepOutput struct {
 
 type StepOutputGetterManager interface {
 	List(ctx context.Context) ([]*StepOutput, error)
-	ListByStep(ctx context.Context) ([]*StepOutput, error)
+	ListSelf(ctx context.Context) ([]*StepOutput, error)
 	Get(ctx context.Context, stepName, name string) (*StepOutput, error)
 }
 

--- a/pkg/operator/app/workflowrun.go
+++ b/pkg/operator/app/workflowrun.go
@@ -73,7 +73,7 @@ type workflowRunStatusSummariesByTaskName struct {
 	conditions map[string]nebulav1.WorkflowRunStatusSummary
 }
 
-func workflowRunStatusSummaries(ctx context.Context, deps *WorkflowRunDeps, pr *obj.PipelineRun) *workflowRunStatusSummariesByTaskName {
+func workflowRunStatusSummaries(ctx context.Context, wr *obj.WorkflowRun, pr *obj.PipelineRun) *workflowRunStatusSummariesByTaskName {
 	m := &workflowRunStatusSummariesByTaskName{
 		steps:      make(map[string]nebulav1.WorkflowRunStatusSummary),
 		conditions: make(map[string]nebulav1.WorkflowRunStatusSummary),
@@ -85,20 +85,8 @@ func workflowRunStatusSummaries(ctx context.Context, deps *WorkflowRunDeps, pr *
 		}
 
 		if step, ok := taskRunStepStatusSummary(taskRun, name); ok {
-			if step.Status == string(obj.WorkflowRunStatusPending) && workflowRunSkipsPendingSteps(deps.WorkflowRun) {
+			if step.Status == string(obj.WorkflowRunStatusPending) && workflowRunSkipsPendingSteps(wr) {
 				step.Status = string(obj.WorkflowRunStatusSkipped)
-			}
-
-			configMap := configmap.NewLocalConfigMap(deps.MutableConfigMap.Object)
-			modelStep := ModelStep(deps.WorkflowRun, &nebulav1.WorkflowStep{Name: name})
-
-			if outputs, err := configmap.NewStepOutputManager(modelStep, configMap).List(ctx); err == nil {
-				if step.Outputs == nil {
-					step.Outputs = relayv1beta1.NewUnstructuredObject(nil)
-				}
-				for _, output := range outputs {
-					step.Outputs[output.Name] = relayv1beta1.AsUnstructured(output.Value)
-				}
 			}
 
 			m.steps[taskRun.PipelineTaskName] = step
@@ -135,13 +123,13 @@ func ConfigureWorkflowRun(ctx context.Context, deps *WorkflowRunDeps, pr *obj.Pi
 
 	// These are status information organized by task name since we don't yet
 	// have the step names.
-	summariesByTaskName := workflowRunStatusSummaries(ctx, deps, pr)
+	summariesByTaskName := workflowRunStatusSummaries(ctx, wr, pr)
 
 	// This lets us mark pending steps as skipped if they won't ever be run.
 	skipFinder := graph.NewSimpleDirectedGraphWithFeatures(graph.DeterministicIteration)
 
-	// This is the ConfigMap that holds timing information.
-	timingConfigMap := configmap.NewLocalConfigMap(deps.MutableConfigMap.Object)
+	// This is the ConfigMap that holds internal, mutable data (outputs, timing, etc.)
+	configMap := configmap.NewLocalConfigMap(deps.MutableConfigMap.Object)
 
 	for _, step := range wr.Object.Spec.Workflow.Steps {
 		skipFinder.AddVertex(step.Name)
@@ -158,13 +146,20 @@ func ConfigureWorkflowRun(ctx context.Context, deps *WorkflowRunDeps, pr *obj.Pi
 			stepSummary.Status = string(obj.WorkflowRunStatusPending)
 		}
 
-		if timer, err := configmap.NewTimerManager(action, timingConfigMap).Get(ctx, model.TimerStepInit); err == nil {
+		if timer, err := configmap.NewTimerManager(action, configMap).Get(ctx, model.TimerStepInit); err == nil {
 			stepSummary.InitTime = &metav1.Time{Time: timer.Time}
 		}
 
 		// Retain any existing log record.
 		if wr.Object.Status.Steps[step.Name].LogKey != "" {
 			stepSummary.LogKey = wr.Object.Status.Steps[step.Name].LogKey
+		}
+
+		stepSummary.Outputs = relayv1beta1.NewUnstructuredObject(nil)
+		if outputs, err := configmap.NewStepOutputManager(action, configMap).ListByStep(ctx); err == nil {
+			for _, output := range outputs {
+				stepSummary.Outputs[output.Name] = relayv1beta1.AsUnstructured(output.Value)
+			}
 		}
 
 		wr.Object.Status.Steps[step.Name] = stepSummary

--- a/pkg/operator/app/workflowrun.go
+++ b/pkg/operator/app/workflowrun.go
@@ -156,7 +156,7 @@ func ConfigureWorkflowRun(ctx context.Context, deps *WorkflowRunDeps, pr *obj.Pi
 		}
 
 		stepSummary.Outputs = relayv1beta1.NewUnstructuredObject(nil)
-		if outputs, err := configmap.NewStepOutputManager(action, configMap).ListByStep(ctx); err == nil {
+		if outputs, err := configmap.NewStepOutputManager(action, configMap).ListSelf(ctx); err == nil {
 			for _, output := range outputs {
 				stepSummary.Outputs[output.Name] = relayv1beta1.AsUnstructured(output.Value)
 			}


### PR DESCRIPTION
Refactors the existing `StepOutputManager` slightly. Adds a new `ListSelf` function to make it easier to list outputs for the constructed step. A larger refactor/redesign is probably warranted in the future.

`NewStepOutputManager(step *model.Step, cm ConfigMap)` requires a step to be passed in, but this is used inconsistently.
It is required in some cases, but for the `List` function, it is ignoring the step name, and returning all outputs for all steps instead. It uses the `Run` property from the `Step`, but only to pass back as part of the Step data from all steps. Ideally, we update this handling for both consistency.