### PR TITLE
Add 127.0.0.0/8 to bogon filter

### DIFF
--- a/pkg/operator/app/networkpolicy.go
+++ b/pkg/operator/app/networkpolicy.go
@@ -14,6 +14,7 @@ var (
 		"0.0.0.0/8",       // "This host on this network"
 		"10.0.0.0/8",      // Private-Use
 		"100.64.0.0/10",   // Shared Address Space
+		"127.0.0.0/8",     // Loopback
 		"169.254.0.0/16",  // Link Local
 		"172.16.0.0/12",   // Private-Use
 		"192.0.0.0/24",    // IETF Protocol Assignments


### PR DESCRIPTION
Note that this filter applies to inter-pod or pod-to-host networking, not intra-pod networking. I.e., it is still possible to communicate with network servers running in different containers in the same pod.