### PR TITLE
Rename workflow run objects

### DIFF
--- a/pkg/metrics/reconciler/run/reconciler.go
+++ b/pkg/metrics/reconciler/run/reconciler.go
@@ -17,14 +17,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type WorkflowRunReconciler struct {
+type RunReconciler struct {
 	client client.Client
 	meter  *metric.Meter
 }
 
-var _ reconcile.Reconciler = &WorkflowRunReconciler{}
+var _ reconcile.Reconciler = &RunReconciler{}
 
-func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	wr := &relayv1beta1.Run{}
 
 	if err := r.client.Get(ctx, req.NamespacedName, wr); errors.IsNotFound(err) {
@@ -105,7 +105,7 @@ func Add(mgr manager.Manager, meter *metric.Meter) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 16,
 		}).
-		Complete(&WorkflowRunReconciler{
+		Complete(&RunReconciler{
 			client: mgr.GetClient(),
 			meter:  meter,
 		})

--- a/pkg/operator/app/condition.go
+++ b/pkg/operator/app/condition.go
@@ -142,9 +142,9 @@ func NewConditionSet(rd *RunDeps) *ConditionSet {
 			ModelStepObjectKey(
 				client.ObjectKey{
 					Namespace: rd.WorkflowDeps.TenantDeps.Namespace.Name,
-					Name:      rd.WorkflowRun.Key.Name,
+					Name:      rd.Run.Key.Name,
 				},
-				ModelStep(rd.WorkflowRun, ws),
+				ModelStep(rd.Run, ws),
 			),
 		))
 		cs.idx[ws.Name] = i

--- a/pkg/operator/app/configmap.go
+++ b/pkg/operator/app/configmap.go
@@ -49,7 +49,7 @@ func ConfigureImmutableConfigMapForWebhookTrigger(ctx context.Context, cm *corev
 	return nil
 }
 
-func ConfigureImmutableConfigMapForWorkflowRun(ctx context.Context, cm *corev1obj.ConfigMap, rd *RunDeps) error {
+func ConfigureImmutableConfigMapForRun(ctx context.Context, cm *corev1obj.ConfigMap, rd *RunDeps) error {
 	// This implementation manages the underlying object, so no need to retrieve
 	// it later.
 	lcm := configmap.NewLocalConfigMap(cm.Object)
@@ -66,7 +66,7 @@ func ConfigureImmutableConfigMapForWorkflowRun(ctx context.Context, cm *corev1ob
 		}
 	}
 
-	wrp := rd.WorkflowRun.Object.Spec.Parameters
+	wrp := rd.Run.Object.Spec.Parameters
 	for name, value := range wrp {
 		params[name] = value.DeepCopy()
 	}
@@ -80,7 +80,7 @@ func ConfigureImmutableConfigMapForWorkflowRun(ctx context.Context, cm *corev1ob
 	configMapData := make(map[string]string)
 
 	for _, step := range rd.Workflow.Object.Spec.Steps {
-		sm := ModelStep(rd.WorkflowRun, step)
+		sm := ModelStep(rd.Run, step)
 
 		if len(step.Spec) > 0 {
 			if _, err := configmap.NewSpecManager(sm, lcm).Set(ctx, step.Spec.Value()); err != nil {
@@ -127,11 +127,11 @@ func ConfigureImmutableConfigMapForWorkflowRun(ctx context.Context, cm *corev1ob
 	return nil
 }
 
-func ConfigureMutableConfigMapForWorkflowRun(ctx context.Context, cm *corev1obj.ConfigMap, wr *obj.WorkflowRun) error {
+func ConfigureMutableConfigMapForRun(ctx context.Context, cm *corev1obj.ConfigMap, r *obj.Run) error {
 	lcm := configmap.NewLocalConfigMap(cm.Object)
 
-	for stepName, state := range wr.Object.Spec.State.Steps {
-		sm := configmap.NewStateManager(ModelStepFromName(wr, stepName), lcm)
+	for stepName, state := range r.Object.Spec.State.Steps {
+		sm := configmap.NewStateManager(ModelStepFromName(r, stepName), lcm)
 
 		for name, value := range state {
 			if _, err := sm.Set(ctx, name, value.Value()); err != nil {

--- a/pkg/operator/app/networkpolicy.go
+++ b/pkg/operator/app/networkpolicy.go
@@ -74,8 +74,8 @@ func ConfigureNetworkPolicyForTenant(np *networkingv1obj.NetworkPolicy) {
 	}
 }
 
-func ConfigureNetworkPolicyForWorkflowRun(np *networkingv1obj.NetworkPolicy, wr *obj.WorkflowRun, opts ...NetworkPolicyOption) {
-	np.Object.Spec = baseTenantWorkloadNetworkPolicySpec(wr.PodSelector(), opts)
+func ConfigureNetworkPolicyForRun(np *networkingv1obj.NetworkPolicy, r *obj.Run, opts ...NetworkPolicyOption) {
+	np.Object.Spec = baseTenantWorkloadNetworkPolicySpec(r.PodSelector(), opts)
 }
 
 func ConfigureNetworkPolicyForWebhookTrigger(np *networkingv1obj.NetworkPolicy, wt *obj.WebhookTrigger, opts ...NetworkPolicyOption) {

--- a/pkg/operator/app/pipelinerun.go
+++ b/pkg/operator/app/pipelinerun.go
@@ -14,8 +14,8 @@ import (
 )
 
 func ConfigurePipelineRun(ctx context.Context, pr *obj.PipelineRun, pp *PipelineParts) error {
-	lifecycle.Label(ctx, pr, model.RelayControllerWorkflowRunIDLabel, pp.Deps.WorkflowRun.Key.Name)
-	pr.LabelAnnotateFrom(ctx, pp.Deps.WorkflowRun.Object)
+	lifecycle.Label(ctx, pr, model.RelayControllerWorkflowRunIDLabel, pp.Deps.Run.Key.Name)
+	pr.LabelAnnotateFrom(ctx, pp.Deps.Run.Object)
 
 	if err := pp.Deps.OwnerConfigMap.Own(ctx, pr); err != nil {
 		return err
@@ -24,7 +24,7 @@ func ConfigurePipelineRun(ctx context.Context, pr *obj.PipelineRun, pp *Pipeline
 	if err := DependencyManager.SetDependencyOf(
 		&pr.Object.ObjectMeta,
 		lifecycle.TypedObject{
-			Object: pp.Deps.WorkflowRun.Object,
+			Object: pp.Deps.Run.Object,
 			GVK:    relayv1beta1.RunKind,
 		}); err != nil {
 		return err
@@ -59,7 +59,7 @@ func ConfigurePipelineRun(ctx context.Context, pr *obj.PipelineRun, pp *Pipeline
 		}
 	}
 
-	if pp.Deps.WorkflowRun.IsCancelled() {
+	if pp.Deps.Run.IsCancelled() {
 		pr.Object.Spec.Status = tektonv1beta1.PipelineRunSpecStatusCancelled
 	}
 

--- a/pkg/operator/app/rundeps_test.go
+++ b/pkg/operator/app/rundeps_test.go
@@ -68,7 +68,7 @@ func TestRunDepsConfigureAnnotate(t *testing.T) {
 				},
 			}))
 
-			run := obj.NewWorkflowRun(client.ObjectKey{
+			run := obj.NewRun(client.ObjectKey{
 				Namespace: namespace.Name,
 				Name:      "my-test-run",
 			})
@@ -189,7 +189,7 @@ func TestRunDepsConfigureWorkflowExecutionSink(t *testing.T) {
 				},
 			}))
 
-			run := obj.NewWorkflowRun(client.ObjectKey{
+			run := obj.NewRun(client.ObjectKey{
 				Namespace: namespace.Name,
 				Name:      "my-test-run",
 			})

--- a/pkg/operator/app/task.go
+++ b/pkg/operator/app/task.go
@@ -60,7 +60,7 @@ func ConfigureTask(ctx context.Context, t *obj.Task, rd *RunDeps, ws *relayv1bet
 	args := ws.Args
 
 	if len(ws.Input) > 0 {
-		sm := ModelStep(rd.WorkflowRun, ws)
+		sm := ModelStep(rd.Run, ws)
 
 		vol := corev1.Volume{
 			Name: configVolumeKey(sm),
@@ -189,9 +189,9 @@ func NewTaskSet(rd *RunDeps) *TaskSet {
 			ModelStepObjectKey(
 				client.ObjectKey{
 					Namespace: rd.WorkflowDeps.TenantDeps.Namespace.Name,
-					Name:      rd.WorkflowRun.Key.Name,
+					Name:      rd.Run.Key.Name,
 				},
-				ModelStep(rd.WorkflowRun, ws),
+				ModelStep(rd.Run, ws),
 			),
 		)
 	}

--- a/pkg/operator/app/util.go
+++ b/pkg/operator/app/util.go
@@ -17,15 +17,15 @@ const (
 	ManagedByLabelValue = "relay.sh"
 )
 
-func ModelStepFromName(wr *obj.WorkflowRun, stepName string) *model.Step {
+func ModelStepFromName(r *obj.Run, stepName string) *model.Step {
 	return &model.Step{
-		Run:  model.Run{ID: wr.Object.GetName()},
+		Run:  model.Run{ID: r.Object.GetName()},
 		Name: stepName,
 	}
 }
 
-func ModelStep(wr *obj.WorkflowRun, step *relayv1beta1.Step) *model.Step {
-	return ModelStepFromName(wr, step.Name)
+func ModelStep(r *obj.Run, step *relayv1beta1.Step) *model.Step {
+	return ModelStepFromName(r, step.Name)
 }
 
 func ModelWebhookTrigger(wt *obj.WebhookTrigger) *model.Trigger {


### PR DESCRIPTION
Rename workflow run objects.

Last major shift in naming.

This covers everything but labels, annotations, finalizers, and metrics.
Those may be carefully changed later... possibly...