### PR TITLE
Updating gVisor handling in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - k3s-image: rancher/k3s:v1.21.4-k3s1
-          gvisor-version: latest
-        - k3s-image: rancher/k3s:v1.20.10-k3s1
-          gvisor-version: latest
-        - k3s-image: rancher/k3s:v1.19.14-k3s1
-          gvisor-version: '20210301.0'
+        - k3s-image: rancher/k3s:v1.21.5-k3s2
+          gvisor-version: '20211019'
+        - k3s-image: rancher/k3s:v1.20.11-k3s2
+          gvisor-version: '20211019'
+        - k3s-image: rancher/k3s:v1.19.15-k3s2
+          gvisor-version: '20211019'
     env:
       KUBECONFIG: /tmp/kubeconfig
     steps:

--- a/hack/k3s/config-v1.19.toml.tmpl
+++ b/hack/k3s/config-v1.19.toml.tmpl
@@ -1,7 +1,9 @@
-[plugins.opt]
+version = 2
+
+[plugins."io.containerd.internal.v1".opt]
   path = "{{ .NodeConfig.Containerd.Opt }}"
 
-[plugins.cri]
+[plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   stream_server_port = "10010"
   enable_selinux = {{ .NodeConfig.SELinux }}
@@ -17,38 +19,38 @@
 {{end}}
 
 {{- if .NodeConfig.AgentConfig.Snapshotter }}
-[plugins.cri.containerd]
+[plugins."io.containerd.grpc.v1.cri".containerd]
   disable_snapshot_annotations = true
   snapshotter = "{{ .NodeConfig.AgentConfig.Snapshotter }}"
 {{end}}
 
 {{- if not .NodeConfig.NoFlannel }}
-[plugins.cri.cni]
+[plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "{{ .NodeConfig.AgentConfig.CNIBinDir }}"
   conf_dir = "{{ .NodeConfig.AgentConfig.CNIConfDir }}"
 {{end}}
 
-[plugins.cri.containerd.runtimes.runc]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
   runtime_type = "io.containerd.runc.v2"
 
 {{ if .PrivateRegistryConfig }}
 {{ if .PrivateRegistryConfig.Mirrors }}
-[plugins.cri.registry.mirrors]{{end}}
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]{{end}}
 {{range $k, $v := .PrivateRegistryConfig.Mirrors }}
-[plugins.cri.registry.mirrors."{{$k}}"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$k}}"]
   endpoint = [{{range $i, $j := $v.Endpoints}}{{if $i}}, {{end}}{{printf "%q" .}}{{end}}]
 {{end}}
 
 {{range $k, $v := .PrivateRegistryConfig.Configs }}
 {{ if $v.Auth }}
-[plugins.cri.registry.configs."{{$k}}".auth]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."{{$k}}".auth]
   {{ if $v.Auth.Username }}username = {{ printf "%q" $v.Auth.Username }}{{end}}
   {{ if $v.Auth.Password }}password = {{ printf "%q" $v.Auth.Password }}{{end}}
   {{ if $v.Auth.Auth }}auth = {{ printf "%q" $v.Auth.Auth }}{{end}}
   {{ if $v.Auth.IdentityToken }}identitytoken = {{ printf "%q" $v.Auth.IdentityToken }}{{end}}
 {{end}}
 {{ if $v.TLS }}
-[plugins.cri.registry.configs."{{$k}}".tls]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."{{$k}}".tls]
   {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
   {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
   {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
@@ -57,11 +59,12 @@
 {{end}}
 {{end}}
 
-[plugins.linux]
+[plugins."io.containerd.runtime.v1.linux"]
   shim_debug = true
 
-[plugins.cri.containerd.runtimes.runsc]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
   runtime_type = "io.containerd.runsc.v1"
-[plugins.cri.containerd.runtimes.runsc.options]
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]
   TypeUrl = "io.containerd.runsc.v1.options"
   ConfigPath = "/etc/containerd/runsc.toml"


### PR DESCRIPTION
* Pin gVisor version to `20211019` for CI testing
  * [20211026](https://github.com/google/gvisor/compare/release-20211019.0...release-20211026.0) breaks CI (potentially due to the update to support containerd 1.5)
* Update to the latest k3s images
  * Strictly unnecessary, but always better to take the opportunity to upgrade
* Migrate the containerd config to version 2
  * Unnecessary, but new options will only be supported in version 2, and documentation is starting to trend towards version 2 configurations (i.e. https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
  * (some of these options are now deprecated, but leaving them for now...)