### PR TITLE
Add default command for approvals

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1,7 +1,8 @@
 package model
 
 const (
-	DefaultImage = "alpine:latest"
+	DefaultImage   = "alpine:latest"
+	DefaultCommand = "echo"
 
 	// TODO All tool injection settings should be fully configurable
 

--- a/pkg/operator/app/task.go
+++ b/pkg/operator/app/task.go
@@ -18,8 +18,15 @@ import (
 
 func ConfigureTask(ctx context.Context, t *obj.Task, rd *RunDeps, ws *relayv1beta1.Step) error {
 	image := ws.Image
+	command := ws.Command
+	args := ws.Args
+
+	// FIXME This should return an error instead, as image is currently required
+	// Legacy approval steps are currently using a fake step which will have no image defined
+	// Uses a default command to avoid errors running the fake step
 	if image == "" {
 		image = model.DefaultImage
+		command = model.DefaultCommand
 	}
 
 	container := corev1.Container{
@@ -55,9 +62,6 @@ func ConfigureTask(ctx context.Context, t *obj.Task, rd *RunDeps, ws *relayv1bet
 			},
 		}
 	}
-
-	command := ws.Command
-	args := ws.Args
 
 	if len(ws.Input) > 0 {
 		sm := ModelStep(rd.Run, ws)


### PR DESCRIPTION
Adds a default command for approvals.

The fake step that approvals currently require was previously running without a command. This would just exit without doing anything. (Noting that this requires a not-insignificant amount of time for no purpose, so it's not the best strategy for overall performance either...)

This no longer works with the version of Tekton we are using, as not providing a command causes internal Tekton errors when handling TaskRuns.

In this case, we need an innocuous command to execute that does not add additional processing time (and avoids any sensitive information from being exposed to the pod logs).

NOTE: The current approach to _legacy_ approvals should be considered deprecated. The current condition handling is likely going to be completely removed in the very near term (or at least overhauled to no longer need this, so this is hopefully short-lived).