### PR TITLE
Improved approvals with when conditions

### DIFF
--- a/pkg/metadataapi/server/api/conditions.go
+++ b/pkg/metadataapi/server/api/conditions.go
@@ -67,8 +67,10 @@ check:
 			}
 		}
 	default:
-		utilapi.WriteError(ctx, w, errors.NewConditionTypeError(fmt.Sprintf("%T", vt)))
-		return
+		if rv.Complete() {
+			utilapi.WriteError(ctx, w, errors.NewConditionTypeError(fmt.Sprintf("%T", vt)))
+			return
+		}
 	}
 
 	resp := GetConditionsResponseEnvelope{

--- a/pkg/metadataapi/server/api/conditions.go
+++ b/pkg/metadataapi/server/api/conditions.go
@@ -76,6 +76,8 @@ check:
 	}
 
 	if failed {
+		// Override the resolved flag if the condition failed.
+		resp.Resolved = true
 		resp.Success = false
 		resp.Message = "one or more conditions failed"
 		utilapi.WriteObjectOK(ctx, w, resp)

--- a/pkg/metadataapi/server/api/conditions_test.go
+++ b/pkg/metadataapi/server/api/conditions_test.go
@@ -96,7 +96,7 @@ func TestGetConditions(t *testing.T) {
 					"fubar",
 				}),
 			},
-			ExpectedResolved: false,
+			ExpectedResolved: true,
 			ExpectedSuccess:  false,
 		},
 		{
@@ -111,7 +111,7 @@ func TestGetConditions(t *testing.T) {
 					"fubar",
 				}),
 			},
-			ExpectedResolved: false,
+			ExpectedResolved: true,
 			ExpectedSuccess:  false,
 		},
 	}

--- a/pkg/metadataapi/server/api/conditions_test.go
+++ b/pkg/metadataapi/server/api/conditions_test.go
@@ -64,7 +64,28 @@ func TestGetConditions(t *testing.T) {
 			ExpectedSuccess:  false,
 		},
 		{
-			Name: "Resolution error",
+			Name:             "Explicitly true",
+			Conditions:       true,
+			ExpectedResolved: true,
+			ExpectedSuccess:  true,
+		},
+		{
+			Name:             "Explicitly false",
+			Conditions:       false,
+			ExpectedResolved: true,
+			ExpectedSuccess:  false,
+		},
+		{
+			Name: "Resolution error (single expression)",
+			Conditions: exprtestutil.JSONInvocation("equals", []interface{}{
+				exprtestutil.JSONParameter("param1"),
+				"foobar",
+			}),
+			ExpectedResolved: false,
+			ExpectedSuccess:  false,
+		},
+		{
+			Name: "Resolution error (multiple expressions)",
 			Conditions: []interface{}{
 				exprtestutil.JSONInvocation("equals", []interface{}{
 					exprtestutil.JSONParameter("param1"),
@@ -75,7 +96,14 @@ func TestGetConditions(t *testing.T) {
 			ExpectedSuccess:  false,
 		},
 		{
-			Name: "Condition type error",
+			Name:       "Condition type error (single string)",
+			Conditions: "foobar",
+			ExpectedError: errors.NewConditionTypeError(
+				`string`,
+			),
+		},
+		{
+			Name: "Condition type error (multiple strings)",
 			Conditions: []interface{}{
 				"foobar",
 				"fubar",


### PR DESCRIPTION
Fixes another outstanding known issue with approvals (approvals can hang when combined with conditions even though the condition is known to be false - and it's still waiting on approval anyway).

Builds on the logic added previously, which allows this to be fixed easier.

NOTE: This overloads the meaning of "Resolved" in a potentially confusing way. Resolved in this sense is not specifically equivalent to the expression resolution.  All of this logic is going to be refined (or removed) in the near future as we migrate the overall condition logic.