### PR TITLE
Add step output metadata

### DIFF
--- a/pkg/manager/reject/stepoutput.go
+++ b/pkg/manager/reject/stepoutput.go
@@ -20,8 +20,12 @@ func (*stepOutputManager) Get(ctx context.Context, stepName, name string) (*mode
 	return nil, model.ErrRejected
 }
 
-func (*stepOutputManager) Set(ctx context.Context, name string, value interface{}) (*model.StepOutput, error) {
-	return nil, model.ErrRejected
+func (*stepOutputManager) Set(ctx context.Context, name string, value interface{}) error {
+	return model.ErrRejected
+}
+
+func (*stepOutputManager) SetMetadata(ctx context.Context, name string, metadata *model.StepOutputMetadata) error {
+	return model.ErrRejected
 }
 
 var StepOutputManager model.StepOutputManager = &stepOutputManager{}

--- a/pkg/metadataapi/server/api/outputs.go
+++ b/pkg/metadataapi/server/api/outputs.go
@@ -9,12 +9,17 @@ import (
 	utilapi "github.com/puppetlabs/leg/httputil/api"
 	"github.com/puppetlabs/relay-core/pkg/metadataapi/errors"
 	"github.com/puppetlabs/relay-core/pkg/metadataapi/server/middleware"
+	"github.com/puppetlabs/relay-core/pkg/model"
 )
 
 type GetOutputResponseEnvelope struct {
 	TaskName string                 `json:"task_name"`
 	Key      string                 `json:"key"`
 	Value    transfer.JSONInterface `json:"value"`
+}
+
+type PostOutputMetadataRequestEnvelope struct {
+	Sensitive bool `json:"sensitive"`
 }
 
 func (s *Server) GetOutput(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +75,33 @@ func (s *Server) PutOutput(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := om.Set(ctx, name, value.Data); err != nil {
+	if err := om.Set(ctx, name, value.Data); err != nil {
+		utilapi.WriteError(ctx, w, ModelWriteError(err))
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *Server) PutOutputMetadata(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	managers := middleware.Managers(r)
+	om := managers.StepOutputs()
+
+	name, _ := middleware.Var(r, "name")
+
+	var env PostOutputMetadataRequestEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&env); err != nil {
+		utilapi.WriteError(ctx, w, errors.NewAPIMalformedRequestError().WithCause(err))
+		return
+	}
+
+	metadata := &model.StepOutputMetadata{
+		Sensitive: env.Sensitive,
+	}
+
+	if err := om.SetMetadata(ctx, name, metadata); err != nil {
 		utilapi.WriteError(ctx, w, ModelWriteError(err))
 		return
 	}

--- a/pkg/metadataapi/server/api/outputs.go
+++ b/pkg/metadataapi/server/api/outputs.go
@@ -13,9 +13,10 @@ import (
 )
 
 type GetOutputResponseEnvelope struct {
-	TaskName string                 `json:"task_name"`
-	Key      string                 `json:"key"`
-	Value    transfer.JSONInterface `json:"value"`
+	TaskName string                    `json:"task_name"`
+	Key      string                    `json:"key"`
+	Value    transfer.JSONInterface    `json:"value"`
+	Metadata *model.StepOutputMetadata `json:"metadata"`
 }
 
 type PostOutputMetadataRequestEnvelope struct {
@@ -41,6 +42,7 @@ func (s *Server) GetOutput(w http.ResponseWriter, r *http.Request) {
 		TaskName: output.Step.Name,
 		Key:      output.Name,
 		Value:    transfer.JSONInterface{Data: output.Value},
+		Metadata: output.Metadata,
 	}
 
 	utilapi.WriteObjectOK(ctx, w, env)

--- a/pkg/metadataapi/server/api/server.go
+++ b/pkg/metadataapi/server/api/server.go
@@ -44,6 +44,7 @@ func (s *Server) Route(r *mux.Router) {
 
 	// Outputs
 	r.HandleFunc("/outputs/{name}", s.PutOutput).Methods(http.MethodPut)
+	r.HandleFunc("/outputs/{name}/metadata", s.PutOutputMetadata).Methods(http.MethodPut)
 	r.HandleFunc("/outputs/{stepName}/{name}", s.GetOutput).Methods(http.MethodGet)
 
 	// Secrets

--- a/pkg/model/stepoutput.go
+++ b/pkg/model/stepoutput.go
@@ -5,9 +5,14 @@ import (
 )
 
 type StepOutput struct {
-	Step  *Step
-	Name  string
-	Value interface{}
+	Step     *Step
+	Name     string
+	Value    interface{}
+	Metadata *StepOutputMetadata
+}
+
+type StepOutputMetadata struct {
+	Sensitive bool
 }
 
 type StepOutputGetterManager interface {
@@ -17,7 +22,8 @@ type StepOutputGetterManager interface {
 }
 
 type StepOutputSetterManager interface {
-	Set(ctx context.Context, name string, value interface{}) (*StepOutput, error)
+	Set(ctx context.Context, name string, value interface{}) error
+	SetMetadata(ctx context.Context, name string, metadata *StepOutputMetadata) error
 }
 
 type StepOutputManager interface {


### PR DESCRIPTION
Initial changes for step output sensitivity.
Allows setting step output `metadata` in addition to setting output values.
This was determined to be the best design given the way we set set values (rather than rewrite and break backwards compatibility).

Currently, the `sensitive` field is the only option, but this is purposefully built to be expansive in case other settings are needed in the future.
