### PR TITLE
Avoid ownership of non-ownable dependencies

### DIFF
--- a/pkg/install/app/metadataapideps.go
+++ b/pkg/install/app/metadataapideps.go
@@ -70,7 +70,20 @@ func (md *MetadataAPIDeps) Persist(ctx context.Context, cl client.Client) error 
 		return err
 	}
 
-	objs := []lifecycle.OwnablePersister{
+	os := []lifecycle.Ownable{
+		md.VaultAgentDeps,
+		md.Deployment,
+		md.Service,
+		md.ServiceAccount,
+	}
+
+	for _, o := range os {
+		if err := md.OwnerConfigMap.Own(ctx, o); err != nil {
+			return err
+		}
+	}
+
+	objs := []lifecycle.Persister{
 		md.VaultAgentDeps,
 		md.Deployment,
 		md.Service,
@@ -80,10 +93,6 @@ func (md *MetadataAPIDeps) Persist(ctx context.Context, cl client.Client) error 
 	}
 
 	for _, obj := range objs {
-		if err := md.OwnerConfigMap.Own(ctx, obj); err != nil {
-			return err
-		}
-
 		if err := obj.Persist(ctx, cl); err != nil {
 			return err
 		}

--- a/pkg/install/app/operatordeps.go
+++ b/pkg/install/app/operatordeps.go
@@ -90,7 +90,21 @@ func (od *OperatorDeps) Persist(ctx context.Context, cl client.Client) error {
 		return err
 	}
 
-	objs := []lifecycle.OwnablePersister{
+	os := []lifecycle.Ownable{
+		od.VaultAgentDeps,
+		od.WebhookCertificateControllerDeps,
+		od.Deployment,
+		od.WebhookService,
+		od.ServiceAccount,
+	}
+
+	for _, o := range os {
+		if err := od.OwnerConfigMap.Own(ctx, o); err != nil {
+			return err
+		}
+	}
+
+	objs := []lifecycle.Persister{
 		od.VaultAgentDeps,
 		od.WebhookConfig,
 		od.WebhookCertificateControllerDeps,
@@ -103,10 +117,6 @@ func (od *OperatorDeps) Persist(ctx context.Context, cl client.Client) error {
 	}
 
 	for _, obj := range objs {
-		if err := od.OwnerConfigMap.Own(ctx, obj); err != nil {
-			return err
-		}
-
 		if err := obj.Persist(ctx, cl); err != nil {
 			return err
 		}

--- a/pkg/install/app/webhookcertificatecontrollerdeps.go
+++ b/pkg/install/app/webhookcertificatecontrollerdeps.go
@@ -63,7 +63,18 @@ func (d *WebhookCertificateControllerDeps) Persist(ctx context.Context, cl clien
 		return err
 	}
 
-	objs := []lifecycle.OwnablePersister{
+	os := []lifecycle.Ownable{
+		d.Deployment,
+		d.ServiceAccount,
+	}
+
+	for _, o := range os {
+		if err := d.OwnerConfigMap.Own(ctx, o); err != nil {
+			return err
+		}
+	}
+
+	objs := []lifecycle.Persister{
 		d.Deployment,
 		d.ServiceAccount,
 		d.ClusterRole,
@@ -71,10 +82,6 @@ func (d *WebhookCertificateControllerDeps) Persist(ctx context.Context, cl clien
 	}
 
 	for _, obj := range objs {
-		if err := d.OwnerConfigMap.Own(ctx, obj); err != nil {
-			return err
-		}
-
 		if err := obj.Persist(ctx, cl); err != nil {
 			return err
 		}


### PR DESCRIPTION
Splits `Ownables`/`Persisters` for dependencies with mixed usage. A better pattern for this (without requiring duplication) would probably be ideal in the future.

In this case specifically, removes `ClusterRole`, `ClusterRoleBinding`, and `MutatingWebhookConfiguration `from the list of `Ownables`.