### PR TITLE
Support relay-system namespace existing

### DIFF
--- a/pkg/install/app/coredeps.go
+++ b/pkg/install/app/coredeps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/puppetlabs/relay-core/pkg/install/jwt"
 	"github.com/puppetlabs/relay-core/pkg/obj"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -88,7 +89,7 @@ func (cd *CoreDeps) Persist(ctx context.Context, cl client.Client) error {
 		return err
 	}
 
-	if err := cd.Namespace.Persist(ctx, cl); err != nil {
+	if err := cd.Namespace.Persist(ctx, cl); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 


### PR DESCRIPTION
If the `relay-system` namespace already exists, the Relay installer would continuously error out at the start of reconciliation.

(The Relay dev environment would have already created it, for example; this may change in the future if we fold that logic directly into the Relay installer, but it's likely fair to assume it may have already been validly created beforehand...)

We may want to consider adding an optional flag to the `Persist` handling somewhere to better support this, similar to how we currently have `GetIgnoreNotFound` and `DeleteIgnoreNotFound` to obfuscate/wrap similar functionality.
