### PR TITLE
Cleanup error logging

### DIFF
--- a/pkg/install/app/coredeps.go
+++ b/pkg/install/app/coredeps.go
@@ -152,19 +152,14 @@ func ApplyCoreDeps(ctx context.Context, cl client.Client, c *obj.Core) (*CoreDep
 
 	_, err := cd.Load(ctx, cl)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
 	if err := cd.Configure(ctx); err != nil {
-		klog.Error(err)
-
 		return nil, err
 	}
 
 	if err := cd.Core.Persist(ctx, cl); err != nil {
-		klog.Error(err)
-
 		return nil, err
 	}
 

--- a/pkg/install/reconciler/reconciler.go
+++ b/pkg/install/reconciler/reconciler.go
@@ -43,6 +43,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	cd := app.NewCoreDeps(core)
 
 	if _, err := cd.Load(ctx, r.Client); err != nil {
+		klog.Error(err)
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Small tweaks to error logging.
- Cleans up a few redundant `ApplyCoreDeps` error logs (that were already being logged in the install reconciler, which is preferable).
- Added one missing error log to the install reconciler.