### PR TITLE
Fix webhook service name used in installer

### DIFF
--- a/pkg/install/app/webhookcertificatecontroller.go
+++ b/pkg/install/app/webhookcertificatecontroller.go
@@ -66,7 +66,7 @@ func ConfigureWebhookCertificateControllerContainer(wd *WebhookCertificateContro
 		},
 		{
 			Name:  "RELAY_OPERATOR_SERVICE_NAME",
-			Value: wd.TargetDeployment.Name,
+			Value: helper.SuffixObjectKey(wd.TargetDeployment, "webhook").Name,
 		},
 		{
 			Name:  "RELAY_OPERATOR_CERTIFICATE_SECRET_NAME",


### PR DESCRIPTION
Slight adjustment to the name of the webhook service name used in the Relay Installer to match the service created.