### PR TITLE
Remove unnecessary core load calls

### DIFF
--- a/pkg/install/app/logservicedeps.go
+++ b/pkg/install/app/logservicedeps.go
@@ -26,10 +26,6 @@ type LogServiceDeps struct {
 }
 
 func (ld *LogServiceDeps) Load(ctx context.Context, cl client.Client) (bool, error) {
-	if _, err := ld.Core.Load(ctx, cl); err != nil {
-		return false, err
-	}
-
 	if _, err := ld.VaultAgentDeps.Load(ctx, cl); err != nil {
 		return false, err
 	}

--- a/pkg/install/app/metadataapideps.go
+++ b/pkg/install/app/metadataapideps.go
@@ -28,10 +28,6 @@ type MetadataAPIDeps struct {
 }
 
 func (md *MetadataAPIDeps) Load(ctx context.Context, cl client.Client) (bool, error) {
-	if _, err := md.Core.Load(ctx, cl); err != nil {
-		return false, err
-	}
-
 	if _, err := md.VaultAgentDeps.Load(ctx, cl); err != nil {
 		return false, err
 	}

--- a/pkg/install/app/operatordeps.go
+++ b/pkg/install/app/operatordeps.go
@@ -38,10 +38,6 @@ type OperatorDeps struct {
 }
 
 func (od *OperatorDeps) Load(ctx context.Context, cl client.Client) (bool, error) {
-	if _, err := od.Core.Load(ctx, cl); err != nil {
-		return false, err
-	}
-
 	key := helper.SuffixObjectKey(od.Core.Key, "operator")
 
 	if _, err := od.VaultAgentDeps.Load(ctx, cl); err != nil {

--- a/pkg/install/app/vaultconfigdeps.go
+++ b/pkg/install/app/vaultconfigdeps.go
@@ -49,10 +49,6 @@ type VaultConfigDeps struct {
 }
 
 func (vd *VaultConfigDeps) Load(ctx context.Context, cl client.Client) (bool, error) {
-	if _, err := vd.Core.Load(ctx, cl); err != nil {
-		return false, err
-	}
-
 	key := helper.SuffixObjectKey(vd.Core.Key, vaultInitializationIdentifier)
 
 	vd.OwnerConfigMap = corev1obj.NewConfigMap(helper.SuffixObjectKey(key, "owner"))

--- a/pkg/install/app/webhookcertificatecontrollerdeps.go
+++ b/pkg/install/app/webhookcertificatecontrollerdeps.go
@@ -28,10 +28,6 @@ type WebhookCertificateControllerDeps struct {
 }
 
 func (d *WebhookCertificateControllerDeps) Load(ctx context.Context, cl client.Client) (bool, error) {
-	if _, err := d.Core.Load(ctx, cl); err != nil {
-		return false, err
-	}
-
 	key := helper.SuffixObjectKey(d.Core.Key, "webhook-certificate-controller")
 
 	d.OwnerConfigMap = corev1obj.NewConfigMap(helper.SuffixObjectKey(key, "owner"))


### PR DESCRIPTION
For all of the Installer dependency objects, `Core` is passed into the respective `New` functions and does not need to be loaded again in every `Load` call.

The expectation is that `Core` would have been appropriately loaded prior to calling the various `New` functions (with a static spec that would not be changing from dependency to dependency, and should not need reloading). Further, it would not be considered appropriate use to only initialize the `client.ObjectKey` and require downstream loading in every dependency object (even if using a dependency class in a standalone manner).

Filed under code cleanliness / standards.