### PR TITLE
Add default (passthrough) alerts delegate

### DIFF
--- a/cmd/relay-installer/main.go
+++ b/cmd/relay-installer/main.go
@@ -75,7 +75,7 @@ func main() {
 		log.Fatal("Error creating kubernetes config", err)
 	}
 
-	var alertsDelegate alerts.DelegateFunc
+	alertsDelegate, _ := alerts.DelegateToPassthrough()
 	if sentryDSN != "" {
 		var err error
 		alertsDelegate, err = alerts.DelegateToSentry(sentryDSN)

--- a/cmd/relay-operator/main.go
+++ b/cmd/relay-operator/main.go
@@ -145,7 +145,7 @@ func main() {
 		log.Fatal("Error creating signer for JWTs", err)
 	}
 
-	var alertsDelegate alerts.DelegateFunc
+	alertsDelegate, _ := alerts.DelegateToPassthrough()
 	if *sentryDSN != "" {
 		var err error
 		alertsDelegate, err = alerts.DelegateToSentry(*sentryDSN)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/puppetlabs/errawr-go/v2 v2.2.0
 	github.com/puppetlabs/leg/datastructure v0.1.0
 	github.com/puppetlabs/leg/encoding v0.1.0
-	github.com/puppetlabs/leg/errmap v0.1.0
+	github.com/puppetlabs/leg/errmap v0.1.1
 	github.com/puppetlabs/leg/gvalutil v0.2.0
 	github.com/puppetlabs/leg/hashutil v0.1.0
 	github.com/puppetlabs/leg/httputil v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1772,8 +1772,9 @@ github.com/puppetlabs/leg/datastructure v0.1.0 h1:0703wQJ71etqsPOr+vfiTBHkq0+tVV
 github.com/puppetlabs/leg/datastructure v0.1.0/go.mod h1:4Kwk/83hkiR1smN1gRsi0LJDgVDbD672JpWjRPBVka8=
 github.com/puppetlabs/leg/encoding v0.1.0 h1:9c3wfcc2qQu2WBOHLaCFzy9M5Ykx/LxInRMi6bB4YXA=
 github.com/puppetlabs/leg/encoding v0.1.0/go.mod h1:g0nlkWi36AWq6ldfjqSMjVgcqrSXekcsfVPPKh/+qdw=
-github.com/puppetlabs/leg/errmap v0.1.0 h1:1oH50d/sch1kB5JuIRrLf0hg9gSr5pfAmTUc6o8CtZQ=
 github.com/puppetlabs/leg/errmap v0.1.0/go.mod h1:8oVNaeaaprDjbMYWHj5lLHsD1nsnKZbv0Jw+SjoJ6hY=
+github.com/puppetlabs/leg/errmap v0.1.1 h1:TQrNiAoPTimTD79c/ELQ6luuE/Lc7AIc3TYoFTjcEVY=
+github.com/puppetlabs/leg/errmap v0.1.1/go.mod h1:8oVNaeaaprDjbMYWHj5lLHsD1nsnKZbv0Jw+SjoJ6hY=
 github.com/puppetlabs/leg/graph v0.1.1 h1:S1KCLhbhNcOHpK523mKx+TVN9FdStKE1KDJSNlNOTuo=
 github.com/puppetlabs/leg/graph v0.1.1/go.mod h1:NzQn1eyixNpRC3jW8g7WRLyWeGVlTVZdOUxfU4nS0iI=
 github.com/puppetlabs/leg/gvalutil v0.2.0 h1:fwGciIthyuM1IhjNantSMn2qLWnLXbsA2mTQMIJ1qzY=

--- a/pkg/operator/reconciler/tenant/reconciler.go
+++ b/pkg/operator/reconciler/tenant/reconciler.go
@@ -55,13 +55,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 
 	err = app.ConfigureTenantDeps(ctx, deps)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, errmap.Wrap(err, "failed to configure Tenant dependencies")
 	}
 
 	tdr := app.AsTenantDepsResult(deps, deps.Persist(ctx, r.Client))
 
 	if tdr.Error != nil {
-		return ctrl.Result{}, tdr.Error
+		return ctrl.Result{}, errmap.Wrap(tdr.Error, "failed to persist Tenant dependencies")
 	}
 
 	app.ConfigureTenant(tn, tdr)


### PR DESCRIPTION
Adds the Passthrough alerts delegate as a default (if Sentry is not configured); this logs captured error information by default in any environment without Sentry (i.e. local dev environments or other test environments).
