### PR TITLE
Log service vault config is now optional

### DIFF
--- a/pkg/install/app/vaultengineconfigdeps.go
+++ b/pkg/install/app/vaultengineconfigdeps.go
@@ -151,8 +151,6 @@ func ConfigureVaultConfigJob(
 	authPath := strings.Split(metadataAPIConfig.VaultAuthPath, "/")
 
 	env := []corev1.EnvVar{
-		{Name: logServicePathEnvVar, Value: vaultConfig.Engine.LogServicePath},
-		{Name: logServiceVaultAgentRoleEnvVar, Value: logServiceConfig.VaultAgentRole},
 		{Name: metadataAPIVaultAgentRoleEnvVar, Value: metadataAPIConfig.VaultAgentRole},
 		{Name: operatorVaultAgentRoleEnvVar, Value: operatorConfig.VaultAgentRole},
 		{Name: tenantPathEnvVar, Value: vaultConfig.Engine.TenantPath},
@@ -164,6 +162,12 @@ func ConfigureVaultConfigJob(
 		{Name: vaultNameEnvVar, Value: vaultIdentifier},
 		{Name: vaultNamespaceEnvVar, Value: coreKey.Namespace},
 		{Name: vaultServiceAccountEnvVar, Value: vaultConfig.Engine.AuthDelegatorServiceAccountName},
+	}
+
+	if logServiceConfig != nil {
+		env = append(env,
+			corev1.EnvVar{Name: logServicePathEnvVar, Value: vaultConfig.Engine.LogServicePath},
+			corev1.EnvVar{Name: logServiceVaultAgentRoleEnvVar, Value: logServiceConfig.VaultAgentRole})
 	}
 
 	if jwt != nil {

--- a/pkg/install/vault/init.go
+++ b/pkg/install/vault/init.go
@@ -64,10 +64,6 @@ func (vi *VaultInitializer) InitializeVault(ctx context.Context) error {
 
 	secretEngines := []*model.VaultSecretEngine{
 		{
-			Name: vi.vaultCoreConfig.LogServicePath,
-			Type: model.VaultSecretEngineTypeKVV2,
-		},
-		{
 			Name: vi.vaultCoreConfig.TenantPath,
 			Type: model.VaultSecretEngineTypeKVV2,
 		},
@@ -75,6 +71,13 @@ func (vi *VaultInitializer) InitializeVault(ctx context.Context) error {
 			Name: vi.vaultCoreConfig.TransitPath,
 			Type: model.VaultSecretEngineTypeTransit,
 		},
+	}
+
+	if vi.vaultCoreConfig.LogServicePath != "" {
+		secretEngines = append(secretEngines, &model.VaultSecretEngine{
+			Name: vi.vaultCoreConfig.LogServicePath,
+			Type: model.VaultSecretEngineTypeKVV2,
+		})
 	}
 
 	policyGen := &vaultPolicyGenerator{
@@ -86,10 +89,6 @@ func (vi *VaultInitializer) InitializeVault(ctx context.Context) error {
 
 	policies := []*model.VaultPolicy{
 		{
-			Name:  vi.vaultCoreConfig.LogServiceVaultAgentRole,
-			Rules: string(policyGen.logServicePolicy()),
-		},
-		{
 			Name:  vi.vaultCoreConfig.MetadataAPIVaultAgentRole,
 			Rules: string(policyGen.metadataAPIPolicy()),
 		},
@@ -97,6 +96,13 @@ func (vi *VaultInitializer) InitializeVault(ctx context.Context) error {
 			Name:  vi.vaultCoreConfig.OperatorVaultAgentRole,
 			Rules: string(policyGen.operatorPolicy()),
 		},
+	}
+
+	if vi.vaultCoreConfig.LogServiceVaultAgentRole != "" {
+		policies = append(policies, &model.VaultPolicy{
+			Name:  vi.vaultCoreConfig.LogServiceVaultAgentRole,
+			Rules: string(policyGen.logServicePolicy()),
+		})
 	}
 
 	auth, err := vi.vaultSystemManager.GetAuthMethod(fmt.Sprintf("%s/", vi.vaultConfig.JWTMount))
@@ -117,13 +123,6 @@ func (vi *VaultInitializer) InitializeVault(ctx context.Context) error {
 	// TODO Do not hardcode the service account names
 	kubernetesRoles := []*model.VaultKubernetesRole{
 		{
-			Name:                          vi.vaultCoreConfig.LogServiceVaultAgentRole,
-			BoundServiceAccountNames:      []string{"relay-core-v1-log-service-vault-agent"},
-			BoundServiceAccountNamespaces: []string{vi.vaultConfig.Namespace},
-			Policies:                      []string{vi.vaultCoreConfig.LogServiceVaultAgentRole},
-			TTL:                           "24h",
-		},
-		{
 			Name:                          vi.vaultCoreConfig.MetadataAPIVaultAgentRole,
 			BoundServiceAccountNames:      []string{"relay-core-v1-metadata-api-vault-agent"},
 			BoundServiceAccountNamespaces: []string{vi.vaultConfig.Namespace},
@@ -137,6 +136,16 @@ func (vi *VaultInitializer) InitializeVault(ctx context.Context) error {
 			Policies:                      []string{vi.vaultCoreConfig.OperatorVaultAgentRole},
 			TTL:                           "24h",
 		},
+	}
+
+	if vi.vaultCoreConfig.LogServiceVaultAgentRole != "" {
+		kubernetesRoles = append(kubernetesRoles, &model.VaultKubernetesRole{
+			Name:                          vi.vaultCoreConfig.LogServiceVaultAgentRole,
+			BoundServiceAccountNames:      []string{"relay-core-v1-log-service-vault-agent"},
+			BoundServiceAccountNamespaces: []string{vi.vaultConfig.Namespace},
+			Policies:                      []string{vi.vaultCoreConfig.LogServiceVaultAgentRole},
+			TTL:                           "24h",
+		})
 	}
 
 	// TODO Add installer configuration for `metadata-api-tenant` name


### PR DESCRIPTION
The Log Service is an optional component of the Relay Installer. Continue this pattern to ensure that the Log Service vault configuration is also optional.

NOTE: Currently the vault configuration data is inconsistently organized across multiple objects, but any change to this organization will be done at a later time.