### PR TITLE
Add LogService to RelayInstaller example

### DIFF
--- a/examples/install/relaycore.yaml
+++ b/examples/install/relaycore.yaml
@@ -4,6 +4,7 @@ metadata:
   name: relay-core-v1
   namespace: relay-system
 spec:
+  logService: {}
   metadataAPI: {}
   operator:
     admissionWebhookServer:


### PR DESCRIPTION
Adds the LogService to the default RelayInstaller example (defaults to the new in memory option that is now available).