### PR TITLE
Update wire handling for vault init

### DIFF
--- a/cmd/relay-operator-vault-init/main.go
+++ b/cmd/relay-operator-vault-init/main.go
@@ -7,33 +7,11 @@ import (
 	"strings"
 	"time"
 
-	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/puppetlabs/leg/errmap/pkg/errmark"
 	"github.com/puppetlabs/leg/timeutil/pkg/backoff"
 	"github.com/puppetlabs/leg/timeutil/pkg/retry"
-	vaultutil "github.com/puppetlabs/leg/vaultutil/pkg/vault"
 	"github.com/puppetlabs/relay-core/pkg/install/vault"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-var (
-	DefaultScheme = runtime.NewScheme()
-	schemeBuilder = runtime.NewSchemeBuilder(
-		kubernetesscheme.AddToScheme,
-		metav1.AddMetaToScheme,
-		rbacv1.AddToScheme,
-		apiextensionsv1.AddToScheme,
-		apiextensionsv1beta1.AddToScheme,
-	)
-	_ = schemeBuilder.AddToScheme(DefaultScheme)
 )
 
 var (
@@ -44,10 +22,6 @@ func IsConnectionRefused(err error) bool {
 	return strings.Contains(err.Error(), "connect: connection refused")
 }
 
-type services struct {
-	vault *vaultapi.Client
-}
-
 func main() {
 	ctx := context.Background()
 	vaultConfig, vaultCoreConfig, err := vault.NewConfig()
@@ -55,22 +29,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	svcs, err := InitializeServices(ctx, vaultConfig)
+	vi, err := NewVaultInitializer(ctx, vaultConfig, vaultCoreConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	kubeClient, err := NewKubeClient(DefaultScheme)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	vsc := vaultutil.NewVaultSystemManager(svcs.vault, kubeClient, vaultConfig)
-
-	vc := vault.NewVaultInitializer(vsc, vaultConfig, vaultCoreConfig)
 
 	err = retry.Wait(ctx, func(ctx context.Context) (bool, error) {
-		if err := vc.InitializeVault(ctx); err != nil {
+		if err := vi.InitializeVault(ctx); err != nil {
 			retryOnError := false
 			errmark.If(err, RuleIsConnectionRefused, func(err error) {
 				retryOnError = true
@@ -97,15 +62,4 @@ func main() {
 	}
 
 	os.Exit(0)
-}
-
-func NewKubeClient(scheme *runtime.Scheme) (client.Client, error) {
-	restConfig, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	return client.New(restConfig, client.Options{
-		Scheme: scheme,
-	})
 }

--- a/cmd/relay-operator-vault-init/wire.go
+++ b/cmd/relay-operator-vault-init/wire.go
@@ -1,3 +1,4 @@
+//go:build wireinject
 // +build wireinject
 
 package main
@@ -6,22 +7,31 @@ import (
 	"context"
 
 	"github.com/google/wire"
+	"github.com/puppetlabs/leg/vaultutil/pkg/model"
 	vaultutil "github.com/puppetlabs/leg/vaultutil/pkg/vault"
+	"github.com/puppetlabs/relay-core/pkg/install/op/kube"
 	"github.com/puppetlabs/relay-core/pkg/install/op/vault"
+	vaultinit "github.com/puppetlabs/relay-core/pkg/install/vault"
 )
 
-func vaultConfig(cfg *vaultutil.VaultConfig) vault.Config {
+var VaultSystemManagerProviderSet = wire.NewSet(
+	vaultutil.NewVaultSystemManager,
+)
+
+func vaultConfig(vaultConfig *vaultutil.VaultConfig) vault.Config {
 	return vault.Config{
-		Addr: cfg.VaultAddr.String(),
+		Addr: vaultConfig.VaultAddr.String(),
 	}
 }
 
-func InitializeServices(ctx context.Context, cfg *vaultutil.VaultConfig) (services, error) {
-	wire.Build(
+func NewVaultInitializer(ctx context.Context,
+	config *vaultutil.VaultConfig, coreConfig *vaultinit.VaultCoreConfig) (*vaultinit.VaultInitializer, error) {
+	panic(wire.Build(
+		kube.ProviderSet,
 		vaultConfig,
 		vault.ProviderSet,
-		wire.Struct(new(services), "*"),
-	)
-
-	return services{}, nil
+		VaultSystemManagerProviderSet,
+		wire.Bind(new(model.VaultSystemManager), new(*vaultutil.VaultSystemManager)),
+		vaultinit.ProviderSet,
+	))
 }

--- a/pkg/install/op/kube/kube.go
+++ b/pkg/install/op/kube/kube.go
@@ -1,0 +1,42 @@
+package kube
+
+import (
+	"github.com/google/wire"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var ProviderSet = wire.NewSet(
+	NewKubeScheme,
+	NewKubeClient,
+)
+
+func NewKubeScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	schemeBuilder := runtime.NewSchemeBuilder(
+		kubernetesscheme.AddToScheme,
+		metav1.AddMetaToScheme,
+		rbacv1.AddToScheme,
+		apiextensionsv1.AddToScheme,
+		apiextensionsv1beta1.AddToScheme,
+	)
+	_ = schemeBuilder.AddToScheme(scheme)
+	return scheme
+}
+
+func NewKubeClient(scheme *runtime.Scheme) (client.Client, error) {
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(restConfig, client.Options{
+		Scheme: scheme,
+	})
+}

--- a/pkg/install/vault/init.go
+++ b/pkg/install/vault/init.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/wire"
 	"github.com/puppetlabs/leg/vaultutil/pkg/model"
 	vaultutil "github.com/puppetlabs/leg/vaultutil/pkg/vault"
+)
+
+var ProviderSet = wire.NewSet(
+	NewVaultInitializer,
 )
 
 type VaultInitializer struct {


### PR DESCRIPTION
Improved `wire` handling for vault initialization.
Previously `wire` was only be used to handle the vault client, but it is now initializing the entire vault initialization stack.