### PR TITLE
Do not send validation alerts to Sentry

### DIFF
--- a/pkg/manager/memory/stepmessage.go
+++ b/pkg/manager/memory/stepmessage.go
@@ -1,0 +1,73 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/puppetlabs/relay-core/pkg/model"
+)
+
+type StepMessageKey struct {
+	StepName, ID string
+}
+
+type StepMessageMap struct {
+	mut      sync.RWMutex
+	messages map[StepMessageKey]*model.StepMessage
+}
+
+func (s *StepMessageMap) List(step *model.Step) []*model.StepMessage {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	msgs := make([]*model.StepMessage, 0)
+
+	for key, sm := range s.messages {
+		if step.Name == key.StepName {
+			msgs = append(msgs, sm)
+		}
+	}
+
+	return msgs
+}
+
+func (s *StepMessageMap) Set(key StepMessageKey, message *model.StepMessage) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	s.messages[key] = message
+}
+
+func NewStepMessageMap() *StepMessageMap {
+	return &StepMessageMap{
+		mut:      sync.RWMutex{},
+		messages: make(map[StepMessageKey]*model.StepMessage),
+	}
+}
+
+type StepMessageManager struct {
+	me *model.Step
+	m  *StepMessageMap
+}
+
+func (s *StepMessageManager) List(ctx context.Context) ([]*model.StepMessage, error) {
+	msgs := []*model.StepMessage{}
+	msgs = append(msgs, s.m.List(s.me)...)
+
+	return msgs, nil
+}
+
+func (s *StepMessageManager) Set(ctx context.Context, sm *model.StepMessage) error {
+	s.m.Set(StepMessageKey{StepName: s.me.Name, ID: sm.ID}, sm)
+
+	return nil
+}
+
+var _ model.StepMessageManager = &StepMessageManager{}
+
+func NewStepMessageManager(step *model.Step, backend *StepMessageMap) *StepMessageManager {
+	return &StepMessageManager{
+		me: step,
+		m:  backend,
+	}
+}

--- a/pkg/metadataapi/sample/auth.go
+++ b/pkg/metadataapi/sample/auth.go
@@ -122,6 +122,8 @@ func NewAuthenticator(sc *opt.SampleConfig, key interface{}) *Authenticator {
 			}
 			actionMetadataManager := memory.NewActionMetadataManager(am)
 
+			stepMessageManager := memory.NewStepMessageManager(step, memory.NewStepMessageMap())
+
 			for name, value := range sc.Outputs {
 				som.Set(memory.StepOutputKey{StepName: step.Name, Name: name}, value)
 			}
@@ -140,6 +142,7 @@ func NewAuthenticator(sc *opt.SampleConfig, key interface{}) *Authenticator {
 				mgrs.SetState(stateManager)
 				mgrs.SetActionMetadata(actionMetadataManager)
 				mgrs.SetStepDecorators(stepDecoratorManager)
+				mgrs.SetStepMessages(stepMessageManager)
 				mgrs.SetStepOutputs(stepOutputManager)
 				mgrs.SetTimers(timerManager)
 			}


### PR DESCRIPTION
Validation errors are now being reported via step messages.

* Removes the Sentry alerts for schema validation
* Adds an in-memory option for step messages
* Updates tests to use the in-memory option