### PR TITLE
Modify base image for relay-operator (ko)

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,2 @@
+baseImageOverrides:
+  github.com/puppetlabs/relay-core/cmd/relay-operator: gcr.io/distroless/static:latest


### PR DESCRIPTION
Modifies base image for `relay-operator` to `gcr.io/distroless/static:latest`.