### PR TITLE
Switch entrypoint to ko path

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -8,7 +8,7 @@ const (
 	ToolsImage     = "us-docker.pkg.dev/puppet-relay-contrib-oss/relay-core/relay-runtime-tools:latest"
 	ToolsMountName = "relay-tools"
 	ToolsMountPath = "/var/lib/puppet/relay"
-	ToolsSource    = "/relay/runtime/tools/."
+	ToolsSource    = "/ko-app/relay-runtime-tools"
 )
 
 const (

--- a/pkg/operator/app/knativeservice.go
+++ b/pkg/operator/app/knativeservice.go
@@ -102,7 +102,7 @@ func ConfigureKnativeService(ctx context.Context, s *obj.KnativeService, wtd *We
 		Image:      wtd.RuntimeToolsImage,
 		WorkingDir: "/",
 		Command:    []string{"cp"},
-		Args:       []string{"-r", model.ToolsSource, model.ToolsMountPath},
+		Args:       []string{model.ToolsSource, path.Join(model.ToolsMountPath, model.EntrypointCommand)},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      model.ToolsMountName,

--- a/pkg/operator/app/task.go
+++ b/pkg/operator/app/task.go
@@ -34,7 +34,7 @@ func ConfigureTask(ctx context.Context, t *obj.Task, rd *RunDeps, ws *relayv1bet
 		Image:      rd.RuntimeToolsImage,
 		WorkingDir: "/",
 		Command:    []string{"cp"},
-		Args:       []string{"-r", model.ToolsSource, model.ToolsMountPath},
+		Args:       []string{model.ToolsSource, path.Join(model.ToolsMountPath, model.EntrypointCommand)},
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
Switch entrypoint to `ko` path.

Currently this renames the executable to the currently expected `entrypoint` command.
May change this when we enhance the command support (soon).