### PR TITLE
Add entrypoint initialization

### DIFF
--- a/cmd/relay-runtime-tools/main.go
+++ b/cmd/relay-runtime-tools/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/puppetlabs/relay-core/pkg/entrypoint"
+	"github.com/puppetlabs/relay-core/pkg/entrypoint/cmd"
 )
 
 var (
@@ -20,6 +21,17 @@ var (
 
 func main() {
 	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		commands := cmd.NewMap()
+		if command, ok := commands[flag.Args()[0]]; ok {
+			if err := command.Execute(flag.Args()); err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		os.Exit(0)
+	}
 
 	// FIXME Implement configurable timeouts
 	e := entrypoint.Entrypointer{

--- a/pkg/entrypoint/cmd/cmd.go
+++ b/pkg/entrypoint/cmd/cmd.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/puppetlabs/relay-core/pkg/model"
+)
+
+type Command interface {
+	Execute(args []string) error
+}
+
+func NewMap() map[string]Command {
+	return map[string]Command{
+		model.ToolsCommandInitialize: NewInitializeCommand(),
+	}
+}

--- a/pkg/entrypoint/cmd/initialize.go
+++ b/pkg/entrypoint/cmd/initialize.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/puppetlabs/relay-core/pkg/model"
+	"github.com/puppetlabs/relay-core/pkg/util/file"
+)
+
+type copyTarget struct {
+	destination string
+	source      string
+}
+
+type InitializeCommand struct {
+	entrypoint copyTarget
+}
+
+func (ic *InitializeCommand) Execute(args []string) error {
+	if _, err := os.Stat(ic.entrypoint.destination); errors.Is(err, os.ErrNotExist) {
+		if err := file.Copy(ic.entrypoint.source, ic.entrypoint.destination, 0111); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewInitializeCommand() *InitializeCommand {
+	return &InitializeCommand{
+		entrypoint: copyTarget{
+			destination: path.Join(model.ToolsMountPath, model.EntrypointCommand),
+			source:      model.ToolsSource,
+		},
+	}
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -5,10 +5,11 @@ const (
 	DefaultCommand = "echo"
 
 	// TODO Consider configuration options for runtime tools
-	ToolsImage     = "us-docker.pkg.dev/puppet-relay-contrib-oss/relay-core/relay-runtime-tools:latest"
-	ToolsMountName = "relay-tools"
-	ToolsMountPath = "/var/lib/puppet/relay"
-	ToolsSource    = "/ko-app/relay-runtime-tools"
+	ToolsCommandInitialize = "initialize"
+	ToolsImage             = "us-docker.pkg.dev/puppet-relay-contrib-oss/relay-core/relay-runtime-tools:latest"
+	ToolsMountName         = "relay-tools"
+	ToolsMountPath         = "/var/lib/puppet/relay"
+	ToolsSource            = "/ko-app/relay-runtime-tools"
 )
 
 const (

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -1,0 +1,27 @@
+package file
+
+import (
+	"io"
+	"io/fs"
+	"os"
+)
+
+func Copy(source, destination string, permissions fs.FileMode) error {
+	s, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE, permissions)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	if _, err = io.Copy(d, s); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds entrypoint initialization.

Currently unused; subsequent phased deployments are ready to deploy incrementally to ensure no production steps fail during the brief transition from one system to another.

This allows the use of a fully `distroless` base by removing the need for the `cp` command.

Currently uses rudimentary command logic, which may be replaced with a more robust system later.
