### PR TITLE
Legacy storage client is now optional

### DIFF
--- a/cmd/relay-operator/main.go
+++ b/cmd/relay-operator/main.go
@@ -68,9 +68,12 @@ func main() {
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
 
-	storageUrl, err := url.Parse(*storageAddr)
-	if err != nil {
-		log.Fatal("Error parsing the -storage-addr", err)
+	var storageUrl *url.URL
+	if *storageAddr != "" {
+		storageUrl, err = url.Parse(*storageAddr)
+		if err != nil {
+			log.Fatal("Error parsing the -storage-addr", err)
+		}
 	}
 
 	metadataAPIURL, err := url.Parse(*metadataAPIURLStr)
@@ -78,9 +81,12 @@ func main() {
 		log.Fatal("Error parsing -metadata-api-url", err)
 	}
 
-	blobStore, err := storage.NewBlobStore(*storageUrl)
-	if err != nil {
-		log.Fatal("Error initializing the storage client from the -storage-addr", err)
+	var blobStore storage.BlobStore
+	if storageUrl != nil {
+		blobStore, err = storage.NewBlobStore(*storageUrl)
+		if err != nil {
+			log.Fatal("Error initializing the storage client from the -storage-addr", err)
+		}
 	}
 
 	if *webhookServerKeyDir == "" {

--- a/pkg/operator/reconciler/run/reconciler.go
+++ b/pkg/operator/reconciler/run/reconciler.go
@@ -248,6 +248,10 @@ func (r *Reconciler) uploadLogs(ctx context.Context, run *obj.Run, plr *obj.Pipe
 }
 
 func (r *Reconciler) uploadLog(ctx context.Context, namespace, podName, containerName string) (string, error) {
+	if r.StorageClient == nil {
+		return "", nil
+	}
+
 	key := fmt.Sprintf("%s/%s/%s", namespace, podName, containerName)
 
 	// XXX: We can't do this with the dynamic client yet.


### PR DESCRIPTION
Legacy storage client is now optional. This is going to be removed completely during the next phase of the PLS.
More importantly, this should not be required as part of the `RelayInstaller` functionality, which allows further cleanup of legacy tech debt.