### PR TITLE
Do not validate schema when using input (script)

### DIFF
--- a/pkg/entrypoint/runner.go
+++ b/pkg/entrypoint/runner.go
@@ -57,6 +57,8 @@ func (rr *RealRunner) Run(args ...string) error {
 	var logOut *plspb.LogCreateResponse
 	var logErr *plspb.LogCreateResponse
 
+	name, args := args[0], args[1:]
+
 	// TODO Move the bulk of this logic into the "initialization" command/phase
 	mu := rr.Config.MetadataAPIURL
 	if mu != nil {
@@ -64,8 +66,10 @@ func (rr *RealRunner) Run(args ...string) error {
 			log.Println(err)
 		}
 
-		if err := rr.validateSchemas(ctx, mu); err != nil {
-			log.Println(err)
+		if name != path.Join(model.InputScriptMountPath, model.InputScriptName) {
+			if err := rr.validateSchemas(ctx, mu); err != nil {
+				log.Println(err)
+			}
 		}
 
 		logOut, err = rr.postLog(ctx, mu, &plspb.LogCreateRequest{
@@ -86,8 +90,6 @@ func (rr *RealRunner) Run(args ...string) error {
 			log.Println(err)
 		}
 	}
-
-	name, args := args[0], args[1:]
 
 	// Receive system signals on "rr.signals"
 	if rr.signals == nil {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -8,6 +8,9 @@ const (
 	DefaultImage   = "alpine:latest"
 	DefaultCommand = "echo"
 
+	InputScriptMountPath = "/var/run/puppet/relay/config"
+	InputScriptName      = "input-script"
+
 	// TODO Consider configuration options for runtime tools
 	ToolsCommandInitialize = "initialize"
 	ToolsImage             = "us-docker.pkg.dev/puppet-relay-contrib-oss/relay-core/relay-runtime-tools:latest"

--- a/pkg/operator/app/knativeservice.go
+++ b/pkg/operator/app/knativeservice.go
@@ -184,7 +184,7 @@ func ConfigureKnativeService(ctx context.Context, s *obj.KnativeService, wtd *We
 						Items: []corev1.KeyToPath{
 							{
 								Key:  scriptConfigMapKey(tm),
-								Path: "input-script",
+								Path: model.InputScriptName,
 								Mode: func(i int32) *int32 { return &i }(0755),
 							},
 						},
@@ -196,10 +196,10 @@ func ConfigureKnativeService(ctx context.Context, s *obj.KnativeService, wtd *We
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      config,
 			ReadOnly:  true,
-			MountPath: "/var/run/puppet/relay/config",
+			MountPath: model.InputScriptMountPath,
 		})
 
-		command = "/var/run/puppet/relay/config/input-script"
+		command = path.Join(model.InputScriptMountPath, model.InputScriptName)
 		args = []string{}
 	}
 

--- a/pkg/operator/app/task.go
+++ b/pkg/operator/app/task.go
@@ -94,7 +94,7 @@ func ConfigureTask(ctx context.Context, t *obj.Task, rd *RunDeps, ws *relayv1bet
 					Items: []corev1.KeyToPath{
 						{
 							Key:  scriptConfigMapKey(sm),
-							Path: "input-script",
+							Path: model.InputScriptName,
 							Mode: func(i int32) *int32 { return &i }(0755),
 						},
 					},
@@ -106,10 +106,10 @@ func ConfigureTask(ctx context.Context, t *obj.Task, rd *RunDeps, ws *relayv1bet
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      vol.Name,
 			ReadOnly:  true,
-			MountPath: "/var/run/puppet/relay/config",
+			MountPath: model.InputScriptMountPath,
 		})
 
-		command = "/var/run/puppet/relay/config/input-script"
+		command = path.Join(model.InputScriptMountPath, model.InputScriptName)
 		args = []string{}
 	}
 


### PR DESCRIPTION
Using `input` for steps allows free-form use without any real restriction, and we can't really make a judgement call about whether the schema fields are necessary or not. Given that we consider this (essentially) advanced use for advanced users, it's probably sufficient to turn schema validation off completely for this use case.

In the future, we could consider adding more contextual information about whether the schema validation was checked or not, and make this visible via the UI, but that would be over-engineering a solution at this particularly point in time.