### PR TITLE
Expand configuration of secure logging

### DIFF
--- a/pkg/entrypoint/config.go
+++ b/pkg/entrypoint/config.go
@@ -3,29 +3,39 @@ package entrypoint
 import (
 	"net/url"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/puppetlabs/relay-core/pkg/model"
 )
 
 type Config struct {
-	DeploymentEnvironment *model.DeploymentEnvironment
-	MetadataAPIURL        *url.URL
+	DefaultTimeout time.Duration
+	MetadataAPIURL *url.URL
+	SecureLogging  bool
 }
 
 func NewConfig() *Config {
 	conf := &Config{
-		DeploymentEnvironment: &model.DeploymentEnvironmentDefault,
+		DefaultTimeout: 1 * time.Minute,
+		SecureLogging:  true,
 	}
 
-	if env := os.Getenv(model.EnvironmentVariableDeploymentEnvironment.String()); env != "" {
-		if environment, ok := model.DeploymentEnvironments[env]; ok {
-			conf.DeploymentEnvironment = &environment
+	if env := os.Getenv(model.EnvironmentVariableDefaultTimeout.String()); env != "" {
+		if timeout, err := time.ParseDuration(env); err == nil {
+			conf.DefaultTimeout = timeout
 		}
 	}
 
 	if env := os.Getenv(model.EnvironmentVariableMetadataAPIURL.String()); env != "" {
 		if u, err := url.Parse(env); err == nil {
 			conf.MetadataAPIURL = u
+		}
+	}
+
+	if env := os.Getenv(model.EnvironmentVariableEnableSecureLogging.String()); env != "" {
+		if secureLogging, err := strconv.ParseBool(env); err == nil {
+			conf.SecureLogging = secureLogging
 		}
 	}
 

--- a/pkg/entrypoint/runner.go
+++ b/pkg/entrypoint/runner.go
@@ -72,18 +72,20 @@ func (rr *RealRunner) Run(args ...string) error {
 			}
 		}
 
-		logOut, err = rr.postLog(ctx, mu, &plspb.LogCreateRequest{
-			Name: "stdout",
-		})
-		if err != nil {
-			log.Println(err)
-		}
+		if rr.Config.SecureLogging {
+			logOut, err = rr.postLog(ctx, mu, &plspb.LogCreateRequest{
+				Name: "stdout",
+			})
+			if err != nil {
+				log.Println(err)
+			}
 
-		logErr, err = rr.postLog(ctx, mu, &plspb.LogCreateRequest{
-			Name: "stderr",
-		})
-		if err != nil {
-			log.Println(err)
+			logErr, err = rr.postLog(ctx, mu, &plspb.LogCreateRequest{
+				Name: "stderr",
+			})
+			if err != nil {
+				log.Println(err)
+			}
 		}
 
 		if err := rr.setStepInitTimer(ctx, mu); err != nil {
@@ -360,7 +362,7 @@ func (rr *RealRunner) setStepInitTimer(ctx context.Context, mu *url.URL) error {
 }
 
 func (rr *RealRunner) getResponse(ctx context.Context, request *http.Request, waitOptions []retry.WaitOption) (*http.Response, error) {
-	contextWithTimeout, cancel := context.WithTimeout(ctx, rr.Config.DeploymentEnvironment.Timeout())
+	contextWithTimeout, cancel := context.WithTimeout(ctx, rr.Config.DefaultTimeout)
 	defer cancel()
 
 	var response *http.Response

--- a/pkg/entrypoint/runner_test.go
+++ b/pkg/entrypoint/runner_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/puppetlabs/relay-core/pkg/entrypoint"
-	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +62,8 @@ func TestEntrypointRunnerWithoutMetadataAPIURL(t *testing.T) {
 		Args:       []string{"-la"},
 		Runner: &entrypoint.RealRunner{
 			Config: &entrypoint.Config{
-				DeploymentEnvironment: &model.DeploymentEnvironmentTest,
+				DefaultTimeout: 3 * time.Second,
+				SecureLogging:  false,
 			},
 		},
 	}
@@ -78,8 +78,9 @@ func TestEntrypointRunnerWithInvalidMetadataAPIURL(t *testing.T) {
 		Args:       []string{"-la"},
 		Runner: &entrypoint.RealRunner{
 			Config: &entrypoint.Config{
-				DeploymentEnvironment: &model.DeploymentEnvironmentTest,
-				MetadataAPIURL:        &url.URL{Scheme: "http", Host: "invalid"},
+				DefaultTimeout: 3 * time.Second,
+				MetadataAPIURL: &url.URL{Scheme: "http", Host: "invalid"},
+				SecureLogging:  false,
 			},
 		},
 	}
@@ -102,8 +103,9 @@ func TestEntrypointRunnerWithMockMetadataAPIURL(t *testing.T) {
 			Args:       []string{"-la"},
 			Runner: &entrypoint.RealRunner{
 				Config: &entrypoint.Config{
-					DeploymentEnvironment: &model.DeploymentEnvironmentTest,
-					MetadataAPIURL:        u,
+					DefaultTimeout: 3 * time.Second,
+					MetadataAPIURL: u,
+					SecureLogging:  false,
 				},
 			},
 		}

--- a/pkg/metadataapi/server/middleware/auth.go
+++ b/pkg/metadataapi/server/middleware/auth.go
@@ -188,9 +188,7 @@ func (ka *KubernetesAuthenticator) injector(mgrs *builder.MetadataBuilder, tags 
 			logContext = fmt.Sprintf("tenants/%s/runs/%s/steps/%s", claims.RelayTenantID, claims.RelayRunID, claims.RelayName)
 		}
 
-		// HACK Temporarily disable the logging of steps, pending the next phase of logging improvements.
-		if action.Type() == model.ActionTypeTrigger &&
-			ka.logServiceClient != nil && logContext != "" {
+		if ka.logServiceClient != nil && logContext != "" {
 			mgrs.SetLogs(service.NewLogManager(ka.logServiceClient, logContext))
 		} else {
 			mgrs.SetLogs(reject.LogManager)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -43,8 +43,9 @@ const (
 type EnvironmentVariable string
 
 const (
-	EnvironmentVariableDeploymentEnvironment EnvironmentVariable = "RELAY_DEPLOYMENT_ENVIRONMENT"
-	EnvironmentVariableMetadataAPIURL        EnvironmentVariable = "METADATA_API_URL"
+	EnvironmentVariableDefaultTimeout      EnvironmentVariable = "RELAY_DEFAULT_TIMEOUT"
+	EnvironmentVariableEnableSecureLogging EnvironmentVariable = "RELAY_ENABLE_SECURE_LOGGING"
+	EnvironmentVariableMetadataAPIURL      EnvironmentVariable = "METADATA_API_URL"
 )
 
 func (ev EnvironmentVariable) String() string {
@@ -52,12 +53,17 @@ func (ev EnvironmentVariable) String() string {
 }
 
 type DeploymentEnvironment struct {
-	name    string
-	timeout time.Duration
+	name          string
+	secureLogging bool
+	timeout       time.Duration
 }
 
 func (e DeploymentEnvironment) Name() string {
 	return e.name
+}
+
+func (e DeploymentEnvironment) SecureLogging() bool {
+	return e.secureLogging
 }
 
 func (e DeploymentEnvironment) Timeout() time.Duration {
@@ -65,13 +71,15 @@ func (e DeploymentEnvironment) Timeout() time.Duration {
 }
 
 var (
-	DeploymentEnvironmentDefault = DeploymentEnvironment{
-		name:    "default",
-		timeout: 1 * time.Minute,
+	DeploymentEnvironmentDevelopment = DeploymentEnvironment{
+		name:          "dev",
+		secureLogging: true,
+		timeout:       1 * time.Minute,
 	}
 	DeploymentEnvironmentTest = DeploymentEnvironment{
-		name:    "test",
-		timeout: 5 * time.Second,
+		name:          "test",
+		secureLogging: false,
+		timeout:       5 * time.Second,
 	}
 
 	DeploymentEnvironments = map[string]DeploymentEnvironment{

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -83,7 +83,8 @@ var (
 	}
 
 	DeploymentEnvironments = map[string]DeploymentEnvironment{
-		DeploymentEnvironmentTest.Name(): DeploymentEnvironmentTest,
+		DeploymentEnvironmentDevelopment.Name(): DeploymentEnvironmentDevelopment,
+		DeploymentEnvironmentTest.Name():        DeploymentEnvironmentTest,
 	}
 )
 

--- a/pkg/operator/app/knativeservice.go
+++ b/pkg/operator/app/knativeservice.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/lifecycle"
@@ -113,10 +114,16 @@ func ConfigureKnativeService(ctx context.Context, s *obj.KnativeService, wtd *We
 	}
 
 	if environment, ok := model.DeploymentEnvironments[wtd.Environment]; ok {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  model.EnvironmentVariableDeploymentEnvironment.String(),
-			Value: environment.Name(),
-		})
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name:  model.EnvironmentVariableDefaultTimeout.String(),
+				Value: environment.Timeout().String(),
+			},
+			corev1.EnvVar{
+				Name:  model.EnvironmentVariableEnableSecureLogging.String(),
+				Value: fmt.Sprintf("%t", environment.SecureLogging()),
+			},
+		)
 	}
 
 	toolsContainer := corev1.Container{


### PR DESCRIPTION
Enhance the configurability of secure logging (and the entrypointer in general):
* Slightly better approach to disable the PLS for steps temporarily (performance-related)
* Allows easier testing of upcoming PLS changes in the development environment
* The legacy PVC log storage is being removed, and integrating the PLS into the development environment faster is beneficial on multiple levels
* Streamlined entrypointer configuration

Having the capability to configure the entrypointer will likely remain. Much of this code will probably be removed once the PLS is fully integrated, however.