### PR TITLE
Support multiple operator deployments from install

### DIFF
--- a/examples/install/configmap.yaml
+++ b/examples/install/configmap.yaml
@@ -13,5 +13,5 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: relay-install-operator
+  name: vault-config
   namespace: relay-system

--- a/examples/install/kustomization.yaml
+++ b/examples/install/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- namespace.yaml
 - configmap.yaml
 - relaycore.yaml

--- a/examples/install/namespace.yaml
+++ b/examples/install/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: relay-installer
+  name: relay-system

--- a/examples/install/relaycore.yaml
+++ b/examples/install/relaycore.yaml
@@ -20,5 +20,5 @@ spec:
     server:
       builtIn:
         configMapRef:
-          name: relay-install-operator
+          name: vault-config
     sidecar: {}

--- a/manifests/installer/clusterrole.yaml
+++ b/manifests/installer/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: relay-install-operator
+  name: relay-installer
 rules:
 - apiGroups:
   - ""

--- a/manifests/installer/clusterrolebinding.yaml
+++ b/manifests/installer/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: relay-install-operator
+  name: relay-installer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: relay-install-operator
+  name: relay-installer
 subjects:
 - kind: ServiceAccount
-  name: relay-install-operator
-  namespace: relay-system
+  name: relay-installer
+  namespace: relay-installer

--- a/manifests/installer/deployment.yaml
+++ b/manifests/installer/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: relay-installer
-  namespace: relay-system
+  namespace: relay-installer
 spec:
   selector:
     matchLabels:
@@ -25,5 +25,4 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-      serviceAccount: relay-install-operator
-      serviceAccountName: relay-install-operator
+      serviceAccountName: relay-installer

--- a/manifests/installer/serviceaccount.yaml
+++ b/manifests/installer/serviceaccount.yaml
@@ -1,11 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: relay-core-v1-operator
-  namespace: relay-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: relay-install-operator
-  namespace: relay-system
+  name: relay-installer
+  namespace: relay-installer

--- a/pkg/install/app/logservicedeps.go
+++ b/pkg/install/app/logservicedeps.go
@@ -129,7 +129,7 @@ func NewLogServiceDeps(c *obj.Core) *LogServiceDeps {
 			model.RelayAppNameLabel:       "log-service",
 			model.RelayAppInstanceLabel:   norm.AnyDNSLabelNameSuffixed("log-service-", c.Key.Name),
 			model.RelayAppComponentLabel:  "server",
-			model.RelayAppManagedByLabel:  "relay-install-operator",
+			model.RelayAppManagedByLabel:  "relay-installer",
 		},
 	}
 }

--- a/pkg/install/app/metadataapideps.go
+++ b/pkg/install/app/metadataapideps.go
@@ -137,7 +137,7 @@ func (md *MetadataAPIDeps) Configure(ctx context.Context) error {
 	}
 
 	ConfigureMetadataAPIClusterRole(md.ClusterRole)
-	ConfigureClusterRoleBinding(md.Core, md.ServiceAccount, md.ClusterRoleBinding)
+	ConfigureClusterRoleBinding(md.ServiceAccount, md.ClusterRoleBinding)
 
 	return nil
 }
@@ -151,7 +151,7 @@ func NewMetadataAPIDeps(c *obj.Core) *MetadataAPIDeps {
 			model.RelayAppNameLabel:       "metadata-api",
 			model.RelayAppInstanceLabel:   norm.AnyDNSLabelNameSuffixed("metadata-api-", c.Key.Name),
 			model.RelayAppComponentLabel:  "server",
-			model.RelayAppManagedByLabel:  "relay-install-operator",
+			model.RelayAppManagedByLabel:  "relay-installer",
 		},
 	}
 }

--- a/pkg/install/app/operatordeps.go
+++ b/pkg/install/app/operatordeps.go
@@ -189,11 +189,11 @@ func (od *OperatorDeps) Configure(ctx context.Context) error {
 
 	ConfigureOperatorWebhookConfiguration(od, od.WebhookConfig)
 	ConfigureOperatorClusterRole(od.ClusterRole)
-	ConfigureClusterRoleBinding(od.Core, od.ServiceAccount, od.ClusterRoleBinding)
+	ConfigureClusterRoleBinding(od.ServiceAccount, od.ClusterRoleBinding)
 	ConfigureOperatorDelegateClusterRole(od.DelegateClusterRole)
 
 	if od.Core.Object.Spec.Operator.Standalone {
-		ConfigureClusterRoleBinding(od.Core, od.ServiceAccount, od.DelegateClusterRoleBinding)
+		ConfigureClusterRoleBinding(od.ServiceAccount, od.DelegateClusterRoleBinding)
 	}
 
 	return nil
@@ -208,7 +208,7 @@ func NewOperatorDeps(c *obj.Core) *OperatorDeps {
 			model.RelayAppNameLabel:       "operator",
 			model.RelayAppInstanceLabel:   norm.AnyDNSLabelNameSuffixed("operator-", c.Key.Name),
 			model.RelayAppComponentLabel:  "server",
-			model.RelayAppManagedByLabel:  "relay-install-operator",
+			model.RelayAppManagedByLabel:  "relay-installer",
 		},
 	}
 }

--- a/pkg/install/app/rolebinding.go
+++ b/pkg/install/app/rolebinding.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	corev1obj "github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/api/corev1"
+	rbacv1obj "github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/api/rbacv1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func ConfigureRoleBinding(sa *corev1obj.ServiceAccount, rb *rbacv1obj.RoleBinding) {
+	rb.Object.RoleRef = rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     rbacv1obj.RoleKind.Kind,
+		Name:     rb.Key.Name,
+	}
+
+	found := false
+	for _, subject := range rb.Object.Subjects {
+		if subject.Kind == corev1obj.ServiceAccountKind.Kind &&
+			subject.Name == sa.Key.Name &&
+			subject.Namespace == sa.Key.Namespace {
+			found = true
+		}
+	}
+
+	if !found {
+		rb.Object.Subjects = append(rb.Object.Subjects,
+			rbacv1.Subject{
+				Kind:      corev1obj.ServiceAccountKind.Kind,
+				Name:      sa.Key.Name,
+				Namespace: sa.Key.Namespace,
+			},
+		)
+	}
+}

--- a/pkg/install/app/vaultengineconfigdeps.go
+++ b/pkg/install/app/vaultengineconfigdeps.go
@@ -6,12 +6,14 @@ import (
 
 	batchv1obj "github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/api/batchv1"
 	corev1obj "github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/api/corev1"
+	rbacv1obj "github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/api/rbacv1"
 	"github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/helper"
 	"github.com/puppetlabs/leg/k8sutil/pkg/controller/obj/lifecycle"
 	"github.com/puppetlabs/relay-core/pkg/apis/install.relay.sh/v1alpha1"
 	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/puppetlabs/relay-core/pkg/obj"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,6 +46,9 @@ type VaultEngineConfigDeps struct {
 	ConfigJob           *batchv1obj.Job
 	JWTSigningKeySecret *corev1obj.Secret
 	OwnerConfigMap      *corev1obj.ConfigMap
+	Role                *rbacv1obj.Role
+	RoleBinding         *rbacv1obj.RoleBinding
+	ServiceAccount      *corev1obj.ServiceAccount
 	Labels              map[string]string
 }
 
@@ -54,10 +59,17 @@ func (vd *VaultEngineConfigDeps) Load(ctx context.Context, cl client.Client) (bo
 
 	vd.ConfigJob = batchv1obj.NewJob(key)
 
+	vd.Role = rbacv1obj.NewRole(key)
+	vd.RoleBinding = rbacv1obj.NewRoleBinding(key)
+	vd.ServiceAccount = corev1obj.NewServiceAccount(key)
+
 	loaders := lifecycle.Loaders{
 		vd.OwnerConfigMap,
 		vd.ConfigJob,
 		vd.JWTSigningKeySecret,
+		vd.Role,
+		vd.RoleBinding,
+		vd.ServiceAccount,
 	}
 
 	if _, err := loaders.Load(ctx, cl); err != nil {
@@ -78,6 +90,9 @@ func (vd *VaultEngineConfigDeps) Persist(ctx context.Context, cl client.Client) 
 
 	objs := []lifecycle.OwnablePersister{
 		vd.ConfigJob,
+		vd.Role,
+		vd.RoleBinding,
+		vd.ServiceAccount,
 	}
 
 	for _, obj := range objs {
@@ -107,6 +122,9 @@ func (vd *VaultEngineConfigDeps) Configure(ctx context.Context) error {
 
 	lafs := []lifecycle.LabelAnnotatableFrom{
 		vd.ConfigJob,
+		vd.Role,
+		vd.RoleBinding,
+		vd.ServiceAccount,
 	}
 
 	for _, laf := range lafs {
@@ -115,13 +133,16 @@ func (vd *VaultEngineConfigDeps) Configure(ctx context.Context) error {
 		}
 	}
 
+	ConfigureVaultConfigRole(vd.Role)
+	ConfigureRoleBinding(vd.ServiceAccount, vd.RoleBinding)
+
 	ConfigureVaultConfigJob(
 		vd.Core.Key,
 		vd.Core.Object.Spec.LogService,
 		vd.Core.Object.Spec.MetadataAPI,
 		vd.Core.Object.Spec.Operator,
 		vd.Core.Object.Spec.Vault,
-		vd.ConfigJob, vd.JWTSigningKeySecret)
+		vd.ConfigJob, vd.JWTSigningKeySecret, vd.ServiceAccount)
 
 	return nil
 }
@@ -132,11 +153,26 @@ func NewVaultSystemConfigDeps(c *obj.Core, jwt *corev1obj.Secret) *VaultEngineCo
 		JWTSigningKeySecret: jwt,
 		Labels: map[string]string{
 			model.RelayInstallerNameLabel: c.Key.Name,
-			model.RelayAppManagedByLabel:  "relay-install-operator",
+			model.RelayAppManagedByLabel:  "relay-installer",
 		},
 	}
 
 	return vd
+}
+
+func ConfigureVaultConfigRole(r *rbacv1obj.Role) {
+	r.Object.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"serviceaccounts"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+	}
 }
 
 func ConfigureVaultConfigJob(
@@ -145,7 +181,7 @@ func ConfigureVaultConfigJob(
 	metadataAPIConfig v1alpha1.MetadataAPIConfig,
 	operatorConfig v1alpha1.OperatorConfig,
 	vaultConfig v1alpha1.VaultConfig,
-	job *batchv1obj.Job, jwt *corev1obj.Secret) {
+	job *batchv1obj.Job, jwt *corev1obj.Secret, sa *corev1obj.ServiceAccount) {
 
 	// TODO Determine best approach to handling slight variations in configuration data
 	authPath := strings.Split(metadataAPIConfig.VaultAuthPath, "/")
@@ -206,9 +242,7 @@ func ConfigureVaultConfigJob(
 	}
 
 	job.Object.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
-
-	// TODO Consider supporting separate RBAC for use with this container (or at the very least, should not be hardcoded here)
-	job.Object.Spec.Template.Spec.ServiceAccountName = "relay-install-operator"
+	job.Object.Spec.Template.Spec.ServiceAccountName = sa.Key.Name
 }
 
 func VaultAuthDataEnvVar(name string, vad *v1alpha1.VaultAuthData) (corev1.EnvVar, bool) {

--- a/pkg/install/app/vaultserverbuiltinconfigdeps.go
+++ b/pkg/install/app/vaultserverbuiltinconfigdeps.go
@@ -130,7 +130,14 @@ func (vd *VaultServerBuiltInConfigDeps) Configure(ctx context.Context) error {
 		}
 	}
 
-	ConfigureVaultClusterRoleBinding(vd.Core, vd.ClusterRoleBinding, vd.ServiceAccount)
+	ConfigureClusterRoleBindingWithRoleRef(vd.ServiceAccount, vd.ClusterRoleBinding,
+		rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     rbacv1obj.ClusterRoleKind.Kind,
+			Name:     "system:auth-delegator",
+		},
+	)
+
 	ConfigureVaultService(vd, vd.Service)
 	ConfigureVaultStatefulSet(vd, vd.StatefulSet)
 
@@ -158,23 +165,7 @@ func NewVaultServerBuiltInConfigDeps(c *obj.Core) *VaultServerBuiltInConfigDeps 
 			model.RelayAppNameLabel:       "vault",
 			model.RelayAppInstanceLabel:   norm.AnyDNSLabelNameSuffixed("vault-", c.Key.Name),
 			model.RelayAppComponentLabel:  "server",
-			model.RelayAppManagedByLabel:  "relay-install-operator",
-		},
-	}
-}
-
-func ConfigureVaultClusterRoleBinding(coreobj *obj.Core, crb *rbacv1obj.ClusterRoleBinding, sa *corev1obj.ServiceAccount) {
-	crb.Object.RoleRef = rbacv1.RoleRef{
-		APIGroup: "rbac.authorization.k8s.io",
-		Kind:     "ClusterRole",
-		Name:     "system:auth-delegator",
-	}
-
-	crb.Object.Subjects = []rbacv1.Subject{
-		{
-			Kind:      "ServiceAccount",
-			Name:      sa.Key.Name,
-			Namespace: sa.Key.Namespace,
+			model.RelayAppManagedByLabel:  "relay-installer",
 		},
 	}
 }

--- a/pkg/install/app/webhookcertificatecontrollerdeps.go
+++ b/pkg/install/app/webhookcertificatecontrollerdeps.go
@@ -114,7 +114,7 @@ func (wd *WebhookCertificateControllerDeps) Configure(ctx context.Context) error
 
 	ConfigureWebhookCertificateControllerDeployment(wd, wd.Deployment)
 	ConfigureWebhookCertificateControllerClusterRole(wd.ClusterRole)
-	ConfigureWebhookCertificateControllerClusterRoleBinding(wd.Core, wd.ClusterRoleBinding)
+	ConfigureClusterRoleBinding(wd.ServiceAccount, wd.ClusterRoleBinding)
 
 	return nil
 }
@@ -128,7 +128,7 @@ func NewWebhookCertificateControllerDeps(target types.NamespacedName, c *obj.Cor
 			model.RelayAppNameLabel:       "operator",
 			model.RelayAppInstanceLabel:   "operator-" + c.Key.Name,
 			model.RelayAppComponentLabel:  "webhook-certificate-server",
-			model.RelayAppManagedByLabel:  "relay-install-operator",
+			model.RelayAppManagedByLabel:  "relay-installer",
 		},
 	}
 }


### PR DESCRIPTION
* The Relay Installer can now install multiple, independent Relay Core systems in separate namespaces (ideally using the new `tenantNamespace` option to differentiate)
* Splits the Relay Installer namespace (`relay-installer`) from the Relay Core namespace (`relay-system`) in the default install example.
* Consistently renames `relay-install-operator` to `relay-installer`.