### PR TITLE
Handle conditions not defined (validly)

### DIFF
--- a/pkg/manager/configmap/condition_test.go
+++ b/pkg/manager/configmap/condition_test.go
@@ -4,26 +4,97 @@ import (
 	"context"
 	"testing"
 
+	"github.com/puppetlabs/relay-core/pkg/expr/parse"
 	"github.com/puppetlabs/relay-core/pkg/manager/configmap"
 	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestConditionManager(t *testing.T) {
+func TestConditionManagerWhenConditionsAreDefined(t *testing.T) {
 	ctx := context.Background()
-	step := &model.Step{
-		Run:  model.Run{ID: "foo"},
-		Name: "bar",
+
+	tests := []struct {
+		Name                        string
+		Action                      model.Action
+		Value                       interface{}
+		ExpectedConditionExpression parse.Tree
+	}{
+		{
+			Name: "Valid step and value",
+			Action: &model.Step{
+				Run:  model.Run{ID: "foo"},
+				Name: "bar",
+			},
+			Value:                       true,
+			ExpectedConditionExpression: true,
+		},
+		{
+			Name: "Valid step and nil value",
+			Action: &model.Step{
+				Run:  model.Run{ID: "foo"},
+				Name: "bar",
+			},
+			Value: nil,
+		},
 	}
 
-	cm := configmap.NewConditionManager(step, configmap.NewLocalConfigMap(&corev1.ConfigMap{}))
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			cm := configmap.NewConditionManager(test.Action, configmap.NewLocalConfigMap(&corev1.ConfigMap{}))
 
-	cond, err := cm.Set(ctx, true)
-	require.NoError(t, err)
-	require.Equal(t, true, cond.Tree)
+			condition, err := cm.Set(ctx, test.Value)
+			require.NoError(t, err)
+			require.NotNil(t, condition)
+			require.Equal(t, test.ExpectedConditionExpression, condition.Tree)
 
-	cond, err = cm.Get(ctx)
-	require.NoError(t, err)
-	require.Equal(t, true, cond.Tree)
+			condition, err = cm.Get(ctx)
+
+			require.NoError(t, err)
+			require.NotNil(t, condition)
+			require.Equal(t, test.ExpectedConditionExpression, condition.Tree)
+		})
+	}
+}
+
+func TestConditionManagerWhenNoConditionsAreDefined(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		Name          string
+		Action        model.Action
+		ExpectedError error
+	}{
+		{
+			Name: "Valid step and no value set",
+			Action: &model.Step{
+				Run:  model.Run{ID: "foo"},
+				Name: "bar",
+			},
+			ExpectedError: model.ErrNotFound,
+		},
+		{
+			Name: "Valid trigger and no value set",
+			Action: &model.Trigger{
+				Name: "bar",
+			},
+			ExpectedError: model.ErrNotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			cm := configmap.NewConditionManager(test.Action, configmap.NewLocalConfigMap(&corev1.ConfigMap{}))
+
+			condition, err := cm.Get(ctx)
+
+			if test.ExpectedError != nil {
+				require.Equal(t, test.ExpectedError, err)
+				require.Nil(t, condition)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, condition)
+			}
+		})
+	}
 }

--- a/pkg/metadataapi/server/api/conditions.go
+++ b/pkg/metadataapi/server/api/conditions.go
@@ -28,8 +28,17 @@ func (s *Server) GetConditions(w http.ResponseWriter, r *http.Request) {
 	cm := managers.Conditions()
 
 	condition, err := cm.Get(ctx)
-	if err != nil {
+	if err != nil && err != model.ErrNotFound {
 		utilapi.WriteError(ctx, w, ModelReadError(err))
+		return
+	}
+
+	if condition == nil || condition.Tree == nil {
+		utilapi.WriteObjectOK(ctx, w,
+			GetConditionsResponseEnvelope{
+				Resolved: true,
+				Success:  true,
+			})
 		return
 	}
 

--- a/pkg/metadataapi/server/api/conditions_test.go
+++ b/pkg/metadataapi/server/api/conditions_test.go
@@ -142,6 +142,12 @@ func TestGetConditions(t *testing.T) {
 			ExpectedResolved: true,
 			ExpectedSuccess:  false,
 		},
+		{
+			Name:             "No conditions are defined",
+			Conditions:       nil,
+			ExpectedResolved: true,
+			ExpectedSuccess:  true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
@@ -170,7 +176,6 @@ func TestGetConditions(t *testing.T) {
 
 			h := api.NewHandler(sample.NewAuthenticator(sc, tokenGenerator.Key()))
 
-			// Set the output so the condition can succeed.
 			req, err := http.NewRequest(http.MethodPut, "/outputs/output1", strings.NewReader("foobar"))
 			require.NoError(t, err)
 			req.Header.Set("Authorization", "Bearer "+previousTaskToken)
@@ -179,8 +184,7 @@ func TestGetConditions(t *testing.T) {
 			h.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusCreated, resp.Result().StatusCode)
 
-			// Query the condition to find out whether it succeeded.
-			req, err = http.NewRequest(http.MethodGet, "/conditions", nil)
+			req, err = http.NewRequest(http.MethodGet, "/conditions", http.NoBody)
 			require.NoError(t, err)
 			req.Header.Set("Authorization", "Bearer "+currentTaskToken)
 


### PR DESCRIPTION
The conditions endpoint no longer considers a `When` condition "not found" as an error state.

The conditions endpoint is currently only being checked when a Tekton `Condition` is present, and therefore is only being validly called when a `When` condition is already known to be present. Tekton is removing `Conditions` soon, and the call to the conditions endpoint is being moved into the Relay entrypointer process. The entrypointer process will call the conditions endpoint universally without being aware of whether a `When` condition is present or not (and applies equally to both `Steps` and `Triggers`).

It is (exceedingly) unlikely that a "not found" state indicates an actual error in this case; and if an error occurs creating the underlying condition, that needs handled with the proper locality, and not expressed as an error here, as it is ambiguous at best.