### PR TITLE
Change the step status expression language name

### DIFF
--- a/pkg/expr/evaluate/template.go
+++ b/pkg/expr/evaluate/template.go
@@ -67,8 +67,7 @@ func evaluateTemplate(o *Options) func(ctx context.Context, s string, depth int,
 	env["connections"] = &pathlang.ConnectionTypeResolverAdapter{ConnectionTypeResolver: o.ConnectionTypeResolver}
 	env["outputs"] = &pathlang.OutputTypeResolverAdapter{OutputTypeResolver: o.OutputTypeResolver}
 	env["parameters"] = &pathlang.ParameterTypeResolverAdapter{ParameterTypeResolver: o.ParameterTypeResolver}
-	env["status"] = &pathlang.StatusTypeResolverAdapter{StatusTypeResolver: o.StatusTypeResolver}
-	env["statuses"] = &pathlang.StatusTypeResolverAdapter{StatusTypeResolver: o.StatusTypeResolver}
+	env["steps"] = &pathlang.StatusTypeResolverAdapter{StatusTypeResolver: o.StatusTypeResolver}
 
 	return func(ctx context.Context, s string, depth int, next model.Evaluator) (*model.Result, error) {
 		r, err := query.EvaluateQuery(ctx, model.DefaultEvaluator, query.PathTemplateLanguage(pathlang.WithFunctionMap{Map: o.FunctionMap}), env, s)

--- a/pkg/operator/app/configmap.go
+++ b/pkg/operator/app/configmap.go
@@ -177,8 +177,10 @@ func enrichWhenConditions(ctx context.Context, step *relayv1beta1.Step) []interf
 
 	for dependency, useDefault := range useDefaultDependencyFlow {
 		if useDefault {
+			// TODO Implement a more programmatic way of adding expressions without using the explicit expression language.
+			// TODO Consider adding internal conditions to separate generated expressions from user-defined ones.
 			when = append(when,
-				fmt.Sprintf("${status.'%s'.%s}",
+				fmt.Sprintf("${steps.'%s'.%s}",
 					dependency, model.StatusPropertySucceeded.String()))
 		}
 	}


### PR DESCRIPTION
Change the step status expression language name from "status" to "steps". In the future, we will move outputs under the "steps" keyword as well.