### PR TITLE
Remove timed out as a discrete status

### DIFF
--- a/cmd/relay-metrics/main.go
+++ b/cmd/relay-metrics/main.go
@@ -64,7 +64,6 @@ func processStatuses(ctx context.Context, c client.Client, meter *metric.Meter) 
 			attrs := []attribute.KeyValue{}
 
 			switch cond.Type {
-			case relayv1beta1.RunCancelled, relayv1beta1.RunSucceeded, relayv1beta1.RunTimedOut:
 			case relayv1beta1.RunCompleted:
 				switch cond.Status {
 				case corev1.ConditionFalse:

--- a/manifests/resources/relay.sh_runs.yaml
+++ b/manifests/resources/relay.sh_runs.yaml
@@ -105,7 +105,6 @@ spec:
                       - Cancelled
                       - Completed
                       - Succeeded
-                      - TimedOut
                       type: string
                   required:
                   - lastTransitionTime

--- a/pkg/apis/relay.sh/v1beta1/run_types.go
+++ b/pkg/apis/relay.sh/v1beta1/run_types.go
@@ -45,9 +45,6 @@ const (
 
 	// RunSucceeded indicates a run has succeeded.
 	RunSucceeded RunConditionType = "Succeeded"
-
-	// RunTimedOut indicates a run has timed out.
-	RunTimedOut RunConditionType = "TimedOut"
 )
 
 type RunCondition struct {
@@ -55,7 +52,7 @@ type RunCondition struct {
 
 	// Type is the identifier for this condition.
 	//
-	// +kubebuilder:validation:Enum=Cancelled;Completed;Succeeded;TimedOut
+	// +kubebuilder:validation:Enum=Cancelled;Completed;Succeeded
 	Type RunConditionType `json:"type"`
 }
 

--- a/pkg/metrics/reconciler/run/reconciler.go
+++ b/pkg/metrics/reconciler/run/reconciler.go
@@ -58,12 +58,6 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 					attribute.String(model.MetricAttributeOutcome, string(model.WorkflowRunStatusFailure)),
 				}
 			}
-		case relayv1beta1.RunTimedOut:
-			if cond.Status == corev1.ConditionTrue {
-				attrs = []attribute.KeyValue{
-					attribute.String(model.MetricAttributeOutcome, string(model.WorkflowRunStatusTimedOut)),
-				}
-			}
 		}
 
 		if len(attrs) > 0 {

--- a/pkg/operator/app/run.go
+++ b/pkg/operator/app/run.go
@@ -30,7 +30,6 @@ func ConfigureRunStatus(ctx context.Context, rd *RunDeps, pr *obj.PipelineRun) {
 		relayv1beta1.RunCancelled: {},
 		relayv1beta1.RunCompleted: {},
 		relayv1beta1.RunSucceeded: {},
-		relayv1beta1.RunTimedOut:  {},
 	}
 
 	for _, cond := range rd.Run.Object.Status.Conditions {
@@ -240,7 +239,6 @@ func ConfigureRunWithSpecificStatus(r *obj.Run, rc relayv1beta1.RunConditionType
 		relayv1beta1.RunCancelled: {},
 		relayv1beta1.RunCompleted: {},
 		relayv1beta1.RunSucceeded: {},
-		relayv1beta1.RunTimedOut:  {},
 	}
 
 	for _, cond := range r.Object.Status.Conditions {

--- a/pkg/operator/handler/condition/run.go
+++ b/pkg/operator/handler/condition/run.go
@@ -4,7 +4,6 @@ import (
 	relayv1beta1 "github.com/puppetlabs/relay-core/pkg/apis/relay.sh/v1beta1"
 	"github.com/puppetlabs/relay-core/pkg/model"
 	"github.com/puppetlabs/relay-core/pkg/obj"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 )
@@ -16,7 +15,6 @@ var (
 		relayv1beta1.RunCancelled: runCancelledHandler,
 		relayv1beta1.RunCompleted: runCompletedHandler,
 		relayv1beta1.RunSucceeded: runSucceededHandler,
-		relayv1beta1.RunTimedOut:  runTimedOutHandler,
 	}
 )
 
@@ -81,25 +79,6 @@ var runSucceededHandler = RunConditionHandlerFunc(func(r *obj.Run, pr *obj.Pipel
 
 			return relayv1beta1.Condition{
 				Status: corev1.ConditionTrue,
-			}
-		}
-	}
-
-	return relayv1beta1.Condition{
-		Status: corev1.ConditionUnknown,
-	}
-})
-
-var runTimedOutHandler = RunConditionHandlerFunc(func(r *obj.Run, pr *obj.PipelineRun, statuses []*model.ActionStatus) relayv1beta1.Condition {
-	cs := pr.Object.Status.Status.GetCondition(apis.ConditionSucceeded)
-
-	if cs != nil {
-		switch cs.Status {
-		case corev1.ConditionFalse:
-			if cs.Reason == tektonv1beta1.PipelineRunReasonTimedOut.String() {
-				return relayv1beta1.Condition{
-					Status: corev1.ConditionTrue,
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Removes `TimedOut` as a discrete status (this is already bucketed as a failure, and is unnecessary as a discrete status). If a timed out status were to be added in again, it would be as a reason related to failure and/or system error.