### PR TITLE
Fix ordering of entrypoint functionality

### DIFF
--- a/pkg/entrypoint/runner.go
+++ b/pkg/entrypoint/runner.go
@@ -73,16 +73,6 @@ func (rr *RealRunner) Run(args ...string) error {
 
 	mu := rr.Config.MetadataAPIURL
 	if mu != nil {
-		if err := rr.getEnvironmentVariables(ctx, mu); err != nil {
-			log.Println(err)
-		}
-
-		if name != path.Join(model.InputScriptMountPath, model.InputScriptName) {
-			if err := rr.validateSchemas(ctx, mu); err != nil {
-				log.Println(err)
-			}
-		}
-
 		if rr.Config.SecureLogging {
 			logOut, err = rr.postLog(ctx, mu, &plspb.LogCreateRequest{
 				Name: "stdout",
@@ -153,6 +143,18 @@ func (rr *RealRunner) Run(args ...string) error {
 		} else if whenCondition == nil ||
 			whenCondition.WhenConditionStatus != model.WhenConditionStatusSatisfied {
 			return nil
+		}
+	}
+
+	if mu != nil {
+		if err := rr.getEnvironmentVariables(ctx, mu); err != nil {
+			log.Println(err)
+		}
+
+		if name != path.Join(model.InputScriptMountPath, model.InputScriptName) {
+			if err := rr.validateSchemas(ctx, mu); err != nil {
+				log.Println(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Processing environment variables (and validating schemas) needs to occur after the when conditions are processed, as now all steps will run concurrently. Otherwise, expression values that are referenced may not be resolvable yet.

Ideally, both Metadata API calls wait until all referenced values are fully resolved, but that can be done later.