### PR TITLE
Remove init time metric

### DIFF
--- a/pkg/metrics/reconciler/run/reconciler.go
+++ b/pkg/metrics/reconciler/run/reconciler.go
@@ -78,18 +78,6 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
-	var initTime time.Time
-	for _, step := range wr.Status.Steps {
-		if step.InitializationTime != nil && (initTime.IsZero() || step.InitializationTime.Time.Before(initTime)) {
-			initTime = step.InitializationTime.Time
-		}
-	}
-
-	if !initTime.IsZero() {
-		initTimeRecorder := metric.Must(*r.meter).NewInt64ValueRecorder(model.MetricWorkflowRunInitTimeSeconds)
-		initTimeRecorder.Record(ctx, int64(initTime.Sub(wr.CreationTimestamp.Time)/time.Second), attrs...)
-	}
-
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
The init time metric sporadically causes false alerts due to a known issue (i.e. the time is being recorded after the message is successfully received by the Metadata API, which may be delayed due to transient connection issues rather than being based off an accurate timestamp sent in the payload).

As this is causing incorrect alerts to be fired (and this is no longer a necessary metric to monitor), this metric is being removed completely.